### PR TITLE
【fix】Fixed Boot header jump instruction offset error（Jump 64 bytes）。

### DIFF
--- a/board/tinyvision/start.S
+++ b/board/tinyvision/start.S
@@ -69,7 +69,7 @@
 
 _start:
 	/* Boot head information for BROM */
-	.long 0xea000016
+	.long 0xea00000e
 	.byte 'e', 'G', 'O', 'N', '.', 'B', 'T', '0'
 	.long 0x12345678                                /* checksum */
 	.long __spl_size                                /* spl size */
@@ -80,6 +80,7 @@ _start:
 	.long 0x0                                       /* eGON version */
 	.byte 0x00, 0x00, 0x00, 0x00    				/* platform information - 8byte */
 	.byte 0x34, 0x2e, 0x30, 0x00
+	.long 0, 0, 0, 0				/* reserve */
 
 	.align 5
 _vector:

--- a/board/yuzukilizard/start.S
+++ b/board/yuzukilizard/start.S
@@ -69,7 +69,7 @@
 
 _start:
 	/* Boot head information for BROM */
-	.long 0xea000016
+	.long 0xea00000e
 	.byte 'e', 'G', 'O', 'N', '.', 'B', 'T', '0'
 	.long 0x12345678                                /* checksum */
 	.long __spl_size                                /* spl size */
@@ -80,6 +80,7 @@ _start:
 	.long 0x0                                       /* eGON version */
 	.byte 0x00, 0x00, 0x00, 0x00    				/* platform information - 8byte */
 	.byte 0x34, 0x2e, 0x30, 0x00
+	.long 0, 0, 0, 0				/* reserve */
 
 	.align 5
 _vector:


### PR DESCRIPTION
# 更新内容
1. 修正tinyvision和yuzukilizard中boot header跳转指令偏移错误，原指令.long 0xea000016是跳转到96字节位置，但是头只有48字节，32字节对齐后也只有64字节。
