### PR TITLE
BUG: sunxi_gpio_set_pull: fix old status does not clear correctly

### DIFF
--- a/src/drivers/sys-gpio.c
+++ b/src/drivers/sys-gpio.c
@@ -127,7 +127,7 @@ void sunxi_gpio_set_pull(gpio_t pin, enum gpio_pull_t pull) {
 
     addr = port_addr + GPIO_PUL0 + ((pin_num >> 4) << 2);
     val = read32(addr);
-    val &= ~(v << ((pin_num & 0xf) << 1));
+    val &= ~(0x3 << ((pin_num & 0xf) << 1));
     val |= (v << ((pin_num & 0xf) << 1));
     write32(addr, val);
 


### PR DESCRIPTION
old behavior: 

```c
// Initial status
readl(0x02000114) = 0x0555

// First time set to pull up
sunxi_gpio_set_pull(166, GPIO_PULL_UP);
readl(0x02000114) = 0x1555

// Set to pull down (BUG)
sunxi_gpio_set_pull(166, GPIO_PULL_DOWN);
readl(0x02000114) = 0x3555


// Set to pull up (BUG)
sunxi_gpio_set_pull(166, GPIO_PULL_UP);
readl(0x02000114) = 0x3555
```

fixed behavior: 

```c
// Initial status
readl(0x02000114) = 0x0555

// First time set to pull up
sunxi_gpio_set_pull(166, GPIO_PULL_UP);
readl(0x02000114) = 0x1555

// Set to pull down
sunxi_gpio_set_pull(166, GPIO_PULL_DOWN);
readl(0x02000114) = 0x2555


// Set to pull up
sunxi_gpio_set_pull(166, GPIO_PULL_UP);
readl(0x02000114) = 0x1555
```

https://github.com/xboot/xboot/issues/56