### PR TITLE
[board] avaota-a1: add missing dram_para for all sunxi_dram_init calls

### DIFF
--- a/board/avaota-a1/load_e906/main.c
+++ b/board/avaota-a1/load_e906/main.c
@@ -52,6 +52,8 @@ extern sunxi_i2c_t i2c_pmu;
 
 extern sdhci_t sdhci0;
 
+extern uint32_t dram_para[32];
+
 extern void enable_sram_a3();
 extern void rtc_set_vccio_det_spare();
 extern void set_rpio_power_mode(void);
@@ -202,7 +204,7 @@ int main(void) {
     enable_sram_a3();
 
     /* Initialize the DRAM and enable memory management unit (MMU). */
-    uint64_t dram_size = sunxi_dram_init(NULL);
+    uint64_t dram_size = sunxi_dram_init(&dram_para);
 
     sunxi_clk_dump();
 

--- a/board/avaota-a1/smhc2_test/main.c
+++ b/board/avaota-a1/smhc2_test/main.c
@@ -31,6 +31,8 @@ extern sunxi_i2c_t i2c_pmu;
 
 extern sdhci_t sdhci2;
 
+extern uint32_t dram_para[32];
+
 msh_declare_command(speedtest);
 msh_define_help(speedtest, "Do speed test", "Usage: speedtest\n");
 int cmd_speedtest(int argc, const char **argv) {
@@ -82,7 +84,7 @@ int main(void) {
 
     enable_sram_a3();
 
-    printk_info("DRAM: DRAM Size = %dMB\n", sunxi_dram_init(NULL));
+    printk_info("DRAM: DRAM Size = %dMB\n", sunxi_dram_init(&dram_para));
 
     sunxi_clk_dump();
 

--- a/board/avaota-a1/spi_lcd/main.c
+++ b/board/avaota-a1/spi_lcd/main.c
@@ -43,6 +43,8 @@ extern sunxi_serial_t uart_dbg;
 
 extern sunxi_i2c_t i2c_pmu;
 
+extern uint32_t dram_para[32];
+
 extern void set_rpio_power_mode(void);
 
 extern void rtc_set_vccio_det_spare(void);
@@ -258,7 +260,7 @@ int main(void) {
     enable_sram_a3();
 
     /* Initialize the DRAM and enable memory management unit (MMU). */
-    uint64_t dram_size = sunxi_dram_init(NULL);
+    uint64_t dram_size = sunxi_dram_init(&dram_para);
 
     sunxi_clk_dump();
 

--- a/board/avaota-a1/syter_boot/main.c
+++ b/board/avaota-a1/syter_boot/main.c
@@ -60,6 +60,8 @@ extern sunxi_i2c_t i2c_pmu;
 
 extern sdhci_t sdhci0;
 
+extern uint32_t dram_para[32];
+
 extern void enable_sram_a3();
 extern void rtc_set_vccio_det_spare();
 extern void set_rpio_power_mode(void);
@@ -336,7 +338,7 @@ int main(void) {
     enable_sram_a3();
 
     /* Initialize the DRAM and enable memory management unit (MMU). */
-    uint64_t dram_size = sunxi_dram_init(NULL);
+    uint64_t dram_size = sunxi_dram_init(&dram_para);
 
     sunxi_clk_dump();
 

--- a/board/avaota-a1/syter_boot_bl33/main.c
+++ b/board/avaota-a1/syter_boot_bl33/main.c
@@ -60,6 +60,8 @@ extern sunxi_i2c_t i2c_pmu;
 
 extern sdhci_t sdhci0;
 
+extern uint32_t dram_para[32];
+
 extern void enable_sram_a3();
 extern void rtc_set_vccio_det_spare();
 extern void set_rpio_power_mode(void);
@@ -336,7 +338,7 @@ int main(void) {
     enable_sram_a3();
 
     /* Initialize the DRAM and enable memory management unit (MMU). */
-    uint64_t dram_size = sunxi_dram_init(NULL);
+    uint64_t dram_size = sunxi_dram_init(&dram_para);
 
     sunxi_clk_dump();
 

--- a/board/avaota-a1/syter_boot_uboot/main.c
+++ b/board/avaota-a1/syter_boot_uboot/main.c
@@ -57,6 +57,8 @@ extern sunxi_i2c_t i2c_pmu;
 
 extern sdhci_t sdhci0;
 
+extern uint32_t dram_para[32];
+
 extern void enable_sram_a3();
 extern void rtc_set_vccio_det_spare();
 extern void set_rpio_power_mode(void);
@@ -325,7 +327,7 @@ int main(void) {
     enable_sram_a3();
 
     /* Initialize the DRAM and enable memory management unit (MMU). */
-    uint64_t dram_size = sunxi_dram_init(NULL);
+    uint64_t dram_size = sunxi_dram_init(&dram_para);
 
     sunxi_clk_dump();
 


### PR DESCRIPTION
Fix dram init hangup for some apps

Need more tests

Tested apps:
- syter_boot_uboot
- spi_lcd
- syter_boot_uboot

<details>
  <summary>Log before fix</summary>

```
[    0.000546][I]  _____     _           _____ _ _   
[    0.006798][I] |   __|_ _| |_ ___ ___|  |  |_| |_ 
[    0.013061][I] |__   | | |  _| -_|  _|    -| | _| 
[    0.019332][I] |_____|_  |_| |___|_| |__|__|_|_|  
[    0.025603][I]       |___|                        
[    0.031873][I] ***********************************
[    0.038142][I]  SyterKit v0.2.8 Commit: 028ec0fc
[    0.044225][I]  github.com/YuzukiHD/SyterKit      
[    0.050492][I] ***********************************
[    0.056757][I]  Built by: arm-none-eabi-gcc 14.1.0
[    0.063036][I] 
[    0.065952][I] Model: AvaotaSBC Avaota A1 board.
[    0.072024][I] Core: Arm Octa-Core Cortex-A55 v65 r2p0
[    0.078672][I] Chip SID = *
[    0.085906][I] Chip type = T527M00X0DCH Chip Version = 2 
[    0.095343][I] PMU: Found AXP717 PMU, Addr 0x35
[    0.102872][I] PMU: Found AXP323 PMU
[    0.116814][I] DRAM BOOT DRIVE INFO: V0.6581
[    0.122294][I] Set DRAM Voltage to 1160mv
[    0.127399][I] DRAM_VCC set to 1160 mv
[    0.174903][I] DRAM retraining ten 
[    0.222839][I] DRAM retraining ten 
[    0.233702][I] [AUTO DEBUG]32bit,1 ranks training success!
[    0.248927][I] DRAM CLK =-369098737 MHZ
[    0.253838][I] DRAM Type =8 (3:DDR3,4:DDR4,6:LPDDR2,7:LPDDR3,8:LPDDR4)
[    0.266273][I] phy_dfs_clk1 = 4128M
<hang up here>
```
</details>

<details>
  <summary>Log after fix</summary>

```
[    0.000521][I]  _____     _           _____ _ _   
[    0.006773][I] |   __|_ _| |_ ___ ___|  |  |_| |_ 
[    0.013043][I] |__   | | |  _| -_|  _|    -| | _| 
[    0.019321][I] |_____|_  |_| |___|_| |__|__|_|_|  
[    0.025600][I]       |___|                        
[    0.031876][I] ***********************************
[    0.038144][I]  SyterKit v0.2.8 Commit: 20b6a8b2
[    0.044239][I]  github.com/YuzukiHD/SyterKit      
[    0.050510][I] ***********************************
[    0.056776][I]  Built by: arm-none-eabi-gcc 14.1.0
[    0.063062][I] 
[    0.065980][I] Model: AvaotaSBC Avaota A1 board.
[    0.072059][I] Core: Arm Octa-Core Cortex-A55 v65 r2p0
[    0.078714][I] Chip SID = *
[    0.085966][I] Chip type = T527M00X0DCH Chip Version = 2 
[    0.095226][I] PMU: Found AXP717 PMU, Addr 0x35
[    0.102751][I] PMU: Found AXP323 PMU
[    0.117966][I] DRAM BOOT DRIVE INFO: V0.6581
[    0.123454][I] Set DRAM Voltage to 1160mv
[    0.128593][I] DRAM_VCC set to 1160 mv
[    0.253184][I] DRAM retraining ten 
[    0.376238][I] DRAM retraining ten 
[    0.394502][I] [AUTO DEBUG]32bit,1 ranks training success!
[    0.424540][I] Soft Training Version: T2.0
[    2.324907][I] [SOFT TRAINING] CLK=1200M Stable memtest pass
[    2.331812][I] DRAM CLK =1200 MHZ
[    2.336248][I] DRAM Type =8 (3:DDR3,4:DDR4,6:LPDDR2,7:LPDDR3,8:LPDDR4)
[    2.348343][I] DRAM SIZE =2048 MBytes, para1 = 310a, para2 = 8000000, tpr13 = 6061
[    2.358805][I] DRAM simple test OK.
[    2.363450][I] Init DRAM Done, DRAM Size = 2048M
[    2.389500][I] SMHC: sdhci0 controller initialized
[    2.402787][I]   Capacity: 7.7GB
[    2.407205][I] SHMC: SD card detected
[    2.441368][I] FATFS: read bl31.bin addr=48000000
[    2.461009][I] FATFS: read in 13ms at 5.92MB/S
[    2.466767][I] FATFS: read sunxi.dtb addr=4a200000
[    2.478577][I] FATFS: read in 6ms at 1.32MB/S
[    2.484239][I] FATFS: read Image addr=40080000
[    5.634339][I] FATFS: read in 3145ms at 0.65MB/S
[    5.640288][I] FATFS: read scp.bin addr=48100000
[    5.670268][I] FATFS: read in 25ms at 7.04MB/S
[    5.676026][I] Hit any key to stop autoboot:  0 
[    8.688253][I] ATF: Kernel addr: 0x40080000
[    8.693791][I] ATF: Kernel DTB addr: 0x4a200000
[    8.699722][I] disable mmu ok...
[    8.704297][I] disable dcache ok...
[    8.709156][I] disable icache ok...
[    8.714018][I] free interrupt ok...
NOTICE:  BL31: v2.5(debug):20a8ac62a
<continue boot here>
```
</details>