### PR TITLE
[board] support the xtask burn commands cargo make and cargo flash on 100ask-d1-h

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[alias]
+xtask = "run --package xtask --release --"
+make = "xtask make"
+flash = "xtask flash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,187 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clap"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+dependencies = [
+ "atty",
+ "bitflags 1.3.2",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap-verbosity-flag"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0636f9c040082f8e161555a305f8cec1a1c2828b3d981c812b8c39f4ac00c42c"
+dependencies = [
+ "clap",
+ "log",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
+dependencies = [
+ "nix",
+ "windows-sys",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.158"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+
+[[package]]
+name = "log"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "naked-function"
@@ -26,14 +203,62 @@ checksum = "5b4123e70df5fe0bb370cff166ae453b9c5324a2cfc932c0f7e55498147a0475"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.60",
 ]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "panic-halt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de96540e0ebde571dc55c73d60ef407c653844e6f9a1e2fdbd40c07b9252d812"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -51,6 +276,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "regex"
+version = "1.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -73,7 +344,144 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "byteorder",
+ "clap",
+ "clap-verbosity-flag",
+ "ctrlc",
+ "env_logger",
+ "log",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
 [workspace]
 resolver = "2"
-members = ["board/100ask-d1-h-rs"]
+members = ["board/100ask-d1-h-rs", "board/100ask-d1-h-rs/xtask"]
+default-members = ["board/100ask-d1-h-rs/xtask"]

--- a/board/100ask-d1-h-rs/xtask/Cargo.toml
+++ b/board/100ask-d1-h-rs/xtask/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "3.1.9", features = ["derive"] }
+clap-verbosity-flag = "1.0"
+log = "0.4"
+env_logger = "0.9"
+ctrlc = "3.2"
+byteorder = "1"

--- a/board/100ask-d1-h-rs/xtask/src/main.rs
+++ b/board/100ask-d1-h-rs/xtask/src/main.rs
@@ -1,0 +1,266 @@
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use clap::{Args, Parser, Subcommand};
+use clap_verbosity_flag::Verbosity;
+use log::{error, info, trace};
+use std::env;
+use std::fs::File;
+use std::io::{ErrorKind, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::process::{self, Command, Stdio};
+
+#[derive(Parser)]
+#[clap(name = "xtask")]
+#[clap(about = "Program that help you build and debug d1 flash test project", long_about = None)]
+struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
+    #[clap(flatten)]
+    env: Env,
+    #[clap(flatten)]
+    verbose: Verbosity,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Make ELF and binary for this project
+    Make,
+    /// Build flash and burn into FEL mode board
+    Flash(Flash),
+}
+
+#[derive(Args)]
+struct Flash {
+    #[clap(subcommand)]
+    command: FlashCommands,
+}
+
+#[derive(Subcommand)]
+enum FlashCommands {
+    /// Operate on NAND flash
+    Nand,
+    /// Operate on NOR flash
+    Nor,
+}
+
+#[derive(clap::Args)]
+struct Env {
+    #[clap(
+        long = "release",
+        global = true,
+        help = "Build in release mode",
+        long_help = None,
+    )]
+    release: bool,
+}
+
+fn main() {
+    let args = Cli::parse();
+    env_logger::Builder::new()
+        .filter_level(args.verbose.log_level_filter())
+        .init();
+    match &args.command {
+        Commands::Make => {
+            info!("make D1 flash binary");
+            let binutils_prefix = find_binutils_prefix_or_fail();
+            xtask_build_d1_flash_bt0(&args.env);
+            xtask_binary_d1_flash_bt0(binutils_prefix, &args.env);
+            xtask_finialize_d1_flash_bt0(&args.env);
+        }
+        Commands::Flash(flash) => {
+            info!("build D1 binary and burn");
+            let xfel = find_xfel();
+            xfel_find_connected_device(xfel);
+            let binutils_prefix = find_binutils_prefix_or_fail();
+            xtask_build_d1_flash_bt0(&args.env);
+            xtask_binary_d1_flash_bt0(binutils_prefix, &args.env);
+            xtask_finialize_d1_flash_bt0(&args.env);
+            xtask_burn_d1_flash_bt0(xfel, &flash.command, &args.env);
+        }
+    }
+}
+
+const DEFAULT_TARGET: &'static str = "riscv64imac-unknown-none-elf";
+
+fn xtask_build_d1_flash_bt0(env: &Env) {
+    trace!("build D1 flash bt0");
+    let cargo = env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    trace!("found cargo at {}", cargo);
+    let mut command = Command::new(cargo);
+    command.current_dir(project_root());
+    command.arg("build");
+    command.arg("-p");
+    command.arg("syterkit-100ask-d1-h");
+    if env.release {
+        command.arg("--release");
+    }
+    let status = command.status().unwrap();
+    trace!("cargo returned {}", status);
+    if !status.success() {
+        error!("cargo build failed with {}", status);
+        process::exit(1);
+    }
+}
+
+fn xtask_binary_d1_flash_bt0(prefix: &str, env: &Env) {
+    trace!("objcopy binary, prefix: '{}'", prefix);
+    let status = Command::new(format!("{}objcopy", prefix))
+        .current_dir(dist_dir(env))
+        .arg("syterkit-100ask-d1-h")
+        .arg("--binary-architecture=riscv64")
+        .arg("--strip-all")
+        .args(&["-O", "binary", "syterkit-100ask-d1-h.bin"])
+        .status()
+        .unwrap();
+
+    trace!("objcopy returned {}", status);
+    if !status.success() {
+        error!("objcopy failed with {}", status);
+        process::exit(1);
+    }
+}
+
+const EGON_HEADER_LENGTH: u64 = 0x60;
+
+// This function does:
+// 1. fill in binary length
+// 2. calculate checksum of bt0 image; old checksum value must be filled as stamp value
+fn xtask_finialize_d1_flash_bt0(env: &Env) {
+    let path = dist_dir(env);
+    let mut file = File::options()
+        .read(true)
+        .write(true)
+        .open(path.join("syterkit-100ask-d1-h.bin"))
+        .expect("open output binary file");
+    let total_length = file.metadata().unwrap().len();
+    if total_length < EGON_HEADER_LENGTH {
+        error!(
+            "objcopy binary size less than eGON header length, expected >= {} but is {}",
+            EGON_HEADER_LENGTH, total_length
+        );
+    }
+    let new_len = align_up_to(total_length, 16 * 1024); // align up to 16KB
+    file.set_len(new_len).unwrap();
+    file.seek(SeekFrom::Start(0x10)).unwrap();
+    file.write_u32::<LittleEndian>(new_len as u32).unwrap();
+    file.seek(SeekFrom::Start(0x0C)).unwrap();
+    let mut checksum: u32 = 0;
+    file.seek(SeekFrom::Start(0)).unwrap();
+    loop {
+        match file.read_u32::<LittleEndian>() {
+            Ok(val) => checksum = checksum.wrapping_add(val),
+            Err(e) if e.kind() == ErrorKind::UnexpectedEof => break,
+            Err(e) => error!("io error while calculating checksum: {:?}", e),
+        }
+    }
+    file.seek(SeekFrom::Start(0x0C)).unwrap();
+    file.write_u32::<LittleEndian>(checksum).unwrap();
+    file.sync_all().unwrap(); // save file before automatic closing
+} // for C developers: files are automatically closed when they're out of scope
+
+fn align_up_to(len: u64, target_align: u64) -> u64 {
+    let (div, rem) = (len / target_align, len % target_align);
+    if rem != 0 {
+        (div + 1) * target_align
+    } else {
+        len
+    }
+}
+
+fn xtask_burn_d1_flash_bt0(xfel: &str, flash: &FlashCommands, env: &Env) {
+    trace!("burn flash with xfel {}", xfel);
+    let mut command = Command::new(xfel);
+    command.current_dir(dist_dir(env));
+    match flash {
+        FlashCommands::Nand => command.arg("spinand"),
+        FlashCommands::Nor => command.arg("spinor"),
+    };
+    command.args(["write", "0"]);
+    command.arg("syterkit-100ask-d1-h.bin");
+    let status = command.status().unwrap();
+    trace!("xfel returned {}", status);
+    if !status.success() {
+        error!("xfel failed with {}", status);
+        process::exit(1);
+    }
+}
+
+fn find_xfel() -> &'static str {
+    let mut command = Command::new("xfel");
+    command.stdout(Stdio::null());
+    match command.status() {
+        Ok(status) if status.success() => return "xfel",
+        Ok(status) => match status.code() {
+            Some(code) => {
+                error!("xfel command failed with code {}", code);
+                process::exit(code)
+            }
+            None => error!("xfel command terminated by signal"),
+        },
+        Err(e) if e.kind() == ErrorKind::NotFound => error!(
+            "xfel not found
+    install xfel from: https://github.com/xboot/xfel"
+        ),
+        Err(e) => error!(
+            "I/O error occurred when detecting xfel: {}.
+    Please check your xfel program and try again.",
+            e
+        ),
+    }
+    process::exit(1)
+}
+
+fn xfel_find_connected_device(xfel: &str) {
+    let mut command = Command::new(xfel);
+    command.arg("version");
+    let output = command.output().unwrap();
+    if !output.status.success() {
+        error!("xfel failed with code {}", output.status);
+        error!("Is your device in FEL mode?");
+        process::exit(1);
+    }
+    info!("Found {}", String::from_utf8_lossy(&output.stdout).trim());
+}
+
+fn find_binutils_prefix() -> Option<&'static str> {
+    for prefix in ["rust-", "riscv64-unknown-elf-", "riscv64-linux-gnu-"] {
+        let mut command = Command::new(format!("{}objcopy", prefix));
+        command.arg("--version");
+        command.stdout(Stdio::null());
+        let status = command.status().unwrap();
+        if status.success() {
+            return Some(prefix);
+        }
+    }
+    None
+}
+
+fn find_binutils_prefix_or_fail() -> &'static str {
+    trace!("find binutils");
+    if let Some(ans) = find_binutils_prefix() {
+        trace!("found binutils, prefix is '{}'", ans);
+        return ans;
+    }
+    error!(
+        "no binutils found, try install using:
+    rustup component add llvm-tools-preview
+    cargo install cargo-binutils"
+    );
+    process::exit(1)
+}
+
+fn project_root() -> PathBuf {
+    Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .unwrap()
+        .to_path_buf()
+}
+
+fn dist_dir(env: &Env) -> PathBuf {
+    let mut path_buf = project_root().join("target").join(DEFAULT_TARGET);
+    path_buf = match env.release {
+        false => path_buf.join("debug"),
+        true => path_buf.join("release"),
+    };
+    path_buf
+}


### PR DESCRIPTION
This work is designed to help build and debug D1 flash test projects. It provides two main commands: `cargo make` and `cargo flash`.

-  `make`: generates ELF and binary files for the project.

- `flash`: builds the flash and burns it to the board in FEL mode. there are two sub-commands under the command `flash` , `nand` and `nor`, which are used to manipulate the NAND flash and NOR flash respectively.

When executing the command `make` or `flash`, it performs a number of tasks, including building the project, generating the binary file, resizing and checksuming the binary file, and burning the flash.