### PR TITLE
[board] Rust serial output example and light up led on 100ask-d1-h

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "allwinner-hal"
+version = "0.0.0"
+dependencies = [
+ "embedded-hal",
+ "embedded-io",
+ "embedded-time",
+ "plic",
+ "uart16550",
+ "volatile-register",
+]
+
+[[package]]
+name = "allwinner-rt"
+version = "0.0.0"
+dependencies = [
+ "allwinner-hal",
+ "allwinner-rt-macros",
+ "embedded-hal",
+ "embedded-time",
+ "nb",
+ "plic",
+]
+
+[[package]]
+name = "allwinner-rt-macros"
+version = "0.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +151,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-hal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "embedded-time"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a4b4d10ac48d08bfe3db7688c402baadb244721f30a77ce360bd24c3dffe58"
+dependencies = [
+ "num",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +261,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nb"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,6 +276,68 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "num"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -235,6 +357,12 @@ name = "panic-halt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de96540e0ebde571dc55c73d60ef407c653844e6f9a1e2fdbd40c07b9252d812"
+
+[[package]]
+name = "plic"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad606bf31d67b0e10a161b7df7d6a97dda7be22ce4bebcff889476e867c9b7a"
 
 [[package]]
 name = "proc-macro-error"
@@ -339,6 +467,10 @@ dependencies = [
 name = "syterkit-100ask-d1-h"
 version = "0.1.0"
 dependencies = [
+ "allwinner-hal",
+ "allwinner-rt",
+ "embedded-hal",
+ "embedded-io",
  "naked-function",
  "panic-halt",
 ]
@@ -359,16 +491,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
+name = "uart16550"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "939f6f9ccad815fe3efca8fd06f2ec1620c0387fb1bca2b231b61ce710bffb9b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "vcell"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "volatile-register"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
+dependencies = [
+ "vcell",
+]
 
 [[package]]
 name = "winapi"

--- a/board/100ask-d1-h-rs/Cargo.toml
+++ b/board/100ask-d1-h-rs/Cargo.toml
@@ -11,6 +11,10 @@ default-target = "riscv64imac-unknown-none-elf"
 [dependencies]
 naked-function = "0.1.5"
 panic-halt = "0.2.0"
+allwinner-hal = { git = "https://github.com/rustsbi/allwinner-hal" }
+allwinner-rt = { git = "https://github.com/rustsbi/allwinner-hal" }
+embedded-hal = "1.0.0"
+embedded-io = "0.6.1"
 
 [[bin]]
 name = "syterkit-100ask-d1-h"

--- a/board/100ask-d1-h-rs/build.rs
+++ b/board/100ask-d1-h-rs/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-link-arg=-Tallwinner-rt.ld");
+}


### PR DESCRIPTION
### Work description

The `main.rs` is the main entry point for an embedded Rust program. It initializes a number of hardware devices, including GPIO pins and the UART serial interface, performs the basic I/O operations `Hello World!` through these devices.

- As shown in the video below, it lights up the LED after startup.

https://github.com/user-attachments/assets/df22b989-2737-4133-a273-763e511f0a47

- `Hello World!` the serial output example as shown below.

![serial output Hello World example](https://github.com/user-attachments/assets/fabc1014-706d-4dea-b65a-dcdd8398fabb)

Overall, this work initializes and controls hardware devices to implement specific embedded system functions.

-------------------------------

### Problems solved in the work

1. Driver installation for serial debugging devices: https://sparks.gogo.co.nz/ch340.html
    The shown after successful installation: 
![serial debug driver](https://github.com/user-attachments/assets/ee18dfab-4e34-4486-bbb1-d6efa8be13fb)

2. Allwinner USB Burn-in Driver: https://www.aw-ol.com/downloads/resources/15
    After correctly installation, the board will be able to see the `VID_1f3a_PID_efe8` usb device in the device manager by pressing the **FEL** button first before connecting the usb power supply: 
![Allwinner Driver](https://github.com/user-attachments/assets/52c71e80-716d-4a25-94fe-110a47d26996)

3. Use the xfel for burning: https://github.com/xboot/xfel
    And install the zadig driver according to the instructions in the zip file: 
![zadig](https://github.com/user-attachments/assets/61d963dd-7650-47e5-a0f0-33a360b8c284)

4. Use `xfel spinor write 0 . \1.bin` command to flush the board, reboot, and then can see the output on the serial port (note that if the flush fails, it may be a mismatch between the board's flash types, just replace `spinor` with `spinand`): 
![xfel flash](https://github.com/user-attachments/assets/93819381-7378-443b-83cf-ec03c378d097)

5. Finally, use the xtask burn command `cargo flash nor --release` to burn the `main.rs`: 
![cargo flash nor --release](https://github.com/user-attachments/assets/66dd0a59-dccb-4176-9a55-83abd1853e5e)

-------------------------------

### Related efforts

 ERROR xtask::xfel] xfel not found: https://github.com/rustsbi/rustsbi-d1/pull/7/commits/8ffb0ec8a20c3ed8bb1588a2770f7594f5b2e7b6

cargo flash: #128
