### PR TITLE
[rust] small fixes on syterkit::entry macro, documentation fixes and remove default members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,3 @@ members = [
     "rust/xtask",
     "board/100ask-d1-h-rs",
 ]
-default-members = ["rust/xtask"]

--- a/board/100ask-d1-h-rs/src/bin/hello-world.rs
+++ b/board/100ask-d1-h-rs/src/bin/hello-world.rs
@@ -5,6 +5,6 @@ use panic_halt as _;
 use syterkit::{entry, println, Clocks, Peripherals};
 
 #[entry]
-fn main(p: Peripherals, c: Clocks) {
+fn main(_p: Peripherals, _c: Clocks) {
     println!("Hello World!");
 }

--- a/board/100ask-d1-h-rs/src/bin/init-dram.rs
+++ b/board/100ask-d1-h-rs/src/bin/init-dram.rs
@@ -5,7 +5,7 @@ use panic_halt as _;
 use syterkit::{entry, mctl, println, Clocks, Peripherals};
 
 #[entry]
-fn main(p: Peripherals, c: Clocks) {
+fn main(_p: Peripherals, _c: Clocks) {
     println!("DDR Init");
     let ram_size = mctl::init();
     println!("{}M 🐏", ram_size);

--- a/board/100ask-d1-h-rs/src/bin/led-lightup.rs
+++ b/board/100ask-d1-h-rs/src/bin/led-lightup.rs
@@ -6,7 +6,7 @@ use panic_halt as _;
 use syterkit::{entry, Clocks, Peripherals};
 
 #[entry]
-fn main(p: Peripherals, c: Clocks) {
+fn main(p: Peripherals, _c: Clocks) {
     // light up led
     let mut pb5 = p.gpio.pb5.into_output();
     pb5.set_high().unwrap();

--- a/board/100ask-d1-h-rs/src/main.rs
+++ b/board/100ask-d1-h-rs/src/main.rs
@@ -5,7 +5,7 @@ use panic_halt as _;
 use syterkit::{clock_dump, entry, println, show_banner, Clocks, Peripherals};
 
 #[entry]
-fn main(p: Peripherals, c: Clocks) {
+fn main(p: Peripherals, _c: Clocks) {
     // Display the bootloader banner.
     show_banner();
 

--- a/rust/src/macros.rs
+++ b/rust/src/macros.rs
@@ -10,6 +10,7 @@ pub struct Pads<'a> {
     };
 }
 
+/// Prints to the standard output.
 #[macro_export]
 macro_rules! print {
     ($($arg:tt)*) => {
@@ -17,6 +18,7 @@ macro_rules! print {
     }
 }
 
+/// Prints to the standard output, with a newline.
 #[macro_export]
 macro_rules! println {
     () => ($crate::print!("\r\n"));


### PR DESCRIPTION
This pull request includes:

- Redesigned `syterkit::entry` macro internal functions. Now the users may use any variables they want, without having to avoid macro internal variable names. (The `__syterkit_macro__main` function only have `#stmts` as function body-level namespace)
- Small fixes on documents, remove default members on root Cargo.toml file.