### PR TITLE
[rust] complete `clock_dump` fuction for syterboot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 [[package]]
 name = "allwinner-hal"
 version = "0.0.0"
-source = "git+https://github.com/rustsbi/allwinner-hal#376dd7756a4999152b5516cfd8782e37ed48591f"
+source = "git+https://github.com/rustsbi/allwinner-hal#58547784a67ecc75573523ad8169a1e0e0149bdc"
 dependencies = [
  "embedded-hal",
  "embedded-io",
@@ -27,7 +27,7 @@ dependencies = [
 [[package]]
 name = "allwinner-rt"
 version = "0.0.0"
-source = "git+https://github.com/rustsbi/allwinner-hal#376dd7756a4999152b5516cfd8782e37ed48591f"
+source = "git+https://github.com/rustsbi/allwinner-hal#58547784a67ecc75573523ad8169a1e0e0149bdc"
 dependencies = [
  "allwinner-hal",
  "allwinner-rt-macros",
@@ -40,7 +40,7 @@ dependencies = [
 [[package]]
 name = "allwinner-rt-macros"
 version = "0.0.0"
-source = "git+https://github.com/rustsbi/allwinner-hal#376dd7756a4999152b5516cfd8782e37ed48591f"
+source = "git+https://github.com/rustsbi/allwinner-hal#58547784a67ecc75573523ad8169a1e0e0149bdc"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Now we can run `cargo flash nor --release` command to accquire the following serial output: 
![image](https://github.com/user-attachments/assets/a8c1caa4-4834-4efd-a812-54926f40b001)
