### PR TITLE
[ci] more proper name for check types, small fix

### DIFF
--- a/.github/workflows/Cargo.yml
+++ b/.github/workflows/Cargo.yml
@@ -35,5 +35,4 @@ jobs:
           cargo install cargo-binutils
       - name: Cargo Make
         run: |
-          rustc -vV
           cargo make --release

--- a/.github/workflows/Cargo.yml
+++ b/.github/workflows/Cargo.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly-2024-10-01
+          toolchain: nightly
       - name: Setup env
         run: |
           rustup component add llvm-tools-preview

--- a/.github/workflows/Check.yml
+++ b/.github/workflows/Check.yml
@@ -31,11 +31,13 @@ jobs:
           fi
 
   cargo_check:
+    name: Cargo
     needs: check
     if: ${{ needs.check.outputs.is_rust == 'true' }}
     uses: ./.github/workflows/Cargo.yml
-  
+
   cmake_check:
+    name: CMake
     needs: check
     if: ${{ needs.check.outputs.is_rust == 'false' }}
     uses: ./.github/workflows/CMake.yml

--- a/.github/workflows/Check.yml
+++ b/.github/workflows/Check.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   check:
+    name: Determine Rust or C check
     runs-on: ubuntu-latest
 
     outputs:
@@ -30,8 +31,8 @@ jobs:
             echo "::set-output name=is_rust::false"
           fi
 
-  cargo_check:
-    name: Cargo
+  rust_check:
+    name: Rust
     needs: check
     if: ${{ needs.check.outputs.is_rust == 'true' }}
     uses: ./.github/workflows/Cargo.yml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 [[package]]
 name = "allwinner-hal"
 version = "0.0.0"
-source = "git+https://github.com/rustsbi/allwinner-hal#3af2d8628ae86ed459ed441fe3ee45ade09708f6"
+source = "git+https://github.com/rustsbi/allwinner-hal#5a4b5d3b22114e58ff2028fcae9f5d55a079893b"
 dependencies = [
  "embedded-hal",
  "embedded-io",
@@ -27,7 +27,7 @@ dependencies = [
 [[package]]
 name = "allwinner-rt"
 version = "0.0.0"
-source = "git+https://github.com/rustsbi/allwinner-hal#3af2d8628ae86ed459ed441fe3ee45ade09708f6"
+source = "git+https://github.com/rustsbi/allwinner-hal#5a4b5d3b22114e58ff2028fcae9f5d55a079893b"
 dependencies = [
  "allwinner-hal",
  "allwinner-rt-macros",
@@ -40,7 +40,7 @@ dependencies = [
 [[package]]
 name = "allwinner-rt-macros"
 version = "0.0.0"
-source = "git+https://github.com/rustsbi/allwinner-hal#3af2d8628ae86ed459ed441fe3ee45ade09708f6"
+source = "git+https://github.com/rustsbi/allwinner-hal#5a4b5d3b22114e58ff2028fcae9f5d55a079893b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -484,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
 ]

--- a/rust/xtask/src/main.rs
+++ b/rust/xtask/src/main.rs
@@ -275,9 +275,11 @@ fn find_binutils_prefix() -> Option<&'static str> {
         let mut command = Command::new(format!("{}objcopy", prefix));
         command.arg("--version");
         command.stdout(Stdio::null());
-        let status = command.status().unwrap();
-        if status.success() {
-            return Some(prefix);
+        let status = command.status();
+        if let Ok(status) = status {
+            if status.success() {
+                return Some(prefix);
+            }
         }
     }
     None


### PR DESCRIPTION
Add more friendly error messages when no `objcopy` binary is available.