### PR TITLE
docs(drivers): add detailed documentation for Allwinner platform drivers

### DIFF
--- a/src/drivers/sys-clk.c
+++ b/src/drivers/sys-clk.c
@@ -1,5 +1,12 @@
 /* SPDX-License-Identifier: GPL-2.0+ */
 
+/**
+ * @file sys-clk.c
+ * @brief System clock driver for Allwinner (sunxi) platforms
+ * @details This file provides weak implementations of clock-related functions
+ *          that can be overridden by platform-specific code.
+ */
+
 #include <io.h>
 #include <stdarg.h>
 #include <stdbool.h>
@@ -9,33 +16,88 @@
 
 #include <log.h>
 
+/**
+ * @brief Current high-speed oscillator frequency
+ * @details This external variable holds the current frequency of the high-speed
+ *          oscillator (HOSC) in MHz.
+ */
 extern uint32_t current_hosc_freq;
 
+/**
+ * @brief Initialize system clocks
+ * @details This weak function initializes all system clocks. Platform-specific
+ *          implementations should override this function.
+ */
 void __attribute__((weak)) sunxi_clk_init(void) {
 }
 
+/**
+ * @brief Pre-initialize system clocks
+ * @details This weak function performs preliminary clock initialization before
+ *          the main clock initialization. Platform-specific implementations
+ *          should override this function.
+ */
 void __attribute__((weak)) sunxi_clk_pre_init(void) {
 }
 
+/**
+ * @brief Get high-speed oscillator type
+ * @details This weak function returns the type/frequency of the high-speed
+ *          oscillator (HOSC). The default implementation returns 24 MHz.
+ * @return High-speed oscillator frequency in MHz
+ */
 uint32_t __attribute__((weak)) sunxi_clk_get_hosc_type() {
 	return 24;
 }
 
+/**
+ * @brief Reset system clocks
+ * @details This weak function resets system clocks to their default state.
+ *          Platform-specific implementations should override this function.
+ */
 void __attribute__((weak)) sunxi_clk_reset(void) {
 }
 
+/**
+ * @brief Dump clock information
+ * @details This weak function dumps information about the current clock
+ *          configuration for debugging purposes. Platform-specific
+ *          implementations should override this function.
+ */
 void __attribute__((weak)) sunxi_clk_dump(void) {
 }
 
+/**
+ * @brief Deinitialize USB clocks
+ * @details This weak function deinitializes clocks for USB controllers.
+ *          Platform-specific implementations should override this function.
+ */
 void __attribute__((weak)) sunxi_usb_clk_deinit(void) {
 }
 
+/**
+ * @brief Initialize USB clocks
+ * @details This weak function initializes clocks for USB controllers.
+ *          Platform-specific implementations should override this function.
+ */
 void __attribute__((weak)) sunxi_usb_clk_init(void) {
 }
 
+/**
+ * @brief Get peripheral 1x clock rate
+ * @details This weak function returns the frequency of the peripheral 1x clock.
+ *          The default implementation returns 0.
+ * @return Peripheral 1x clock frequency in Hz
+ */
 uint32_t __attribute__((weak)) sunxi_clk_get_peri1x_rate() {
 	return 0;
 }
 
+/**
+ * @brief Set CPU PLL frequency
+ * @details This weak function configures the CPU PLL to the specified frequency.
+ *          Platform-specific implementations should override this function.
+ * @param freq Target frequency in Hz
+ */
 void __attribute__((weak)) sunxi_clk_set_cpu_pll(uint32_t freq) {
 }

--- a/src/drivers/sys-dma.c
+++ b/src/drivers/sys-dma.c
@@ -1,5 +1,13 @@
 /* SPDX-License-Identifier: GPL-2.0+ */
 
+/**
+ * @file sys-dma.c
+ * @brief System DMA (Direct Memory Access) driver for Allwinner (sunxi) platforms
+ * @details This file implements DMA functionality for transferring data between
+ *          memory and peripherals without CPU intervention, supporting multiple
+ *          channels, interrupt handling, and various DMA operations.
+ */
+
 #include <io.h>
 #include <stdarg.h>
 #include <stdbool.h>
@@ -11,20 +19,52 @@
 
 #include <sys-dma.h>
 
+/**
+ * @def SUNXI_DMA_MAX
+ * @brief Maximum number of DMA channels supported
+ * @details Define the maximum number of DMA channels available in the system.
+ *          Defaults to 4 if not already defined.
+ */
 #ifndef SUNXI_DMA_MAX
 #define SUNXI_DMA_MAX 4
 #endif
 
+/**
+ * @brief Interrupt count tracking variable
+ * @details Tracks the number of active DMA interrupts
+ */
 static int dma_int_cnt = 0;
 
+/**
+ * @brief DMA initialization status
+ * @details Tracks whether DMA has been initialized (-1 = not initialized, >=0 = initialized)
+ */
 static int dma_init_ok = -1;
 
+/**
+ * @brief Array of DMA channel source structures
+ * @details Stores information about each DMA channel's state and configuration
+ */
 static sunxi_dma_source_t dma_channel_source[SUNXI_DMA_MAX];
 
+/**
+ * @brief Array of DMA descriptor structures
+ * @details Stores DMA transfer descriptors for each channel, aligned to 64 bytes
+ */
 static sunxi_dma_desc_t dma_channel_desc[SUNXI_DMA_MAX] __attribute__((aligned(64)));
 
+/**
+ * @brief Base address of DMA registers
+ * @details Stores the base address of the DMA controller registers
+ */
 static uint32_t DMA_REG_BASE = 0x0;
 
+/**
+ * @brief Initialize DMA clock
+ * @details Configures the clock settings for the DMA controller, including bus clock gating,
+ *          DMA reset, and DMA clock gating.
+ * @param dma Pointer to DMA configuration structure containing clock register information
+ */
 void sunxi_dma_clk_init(sunxi_dma_t *dma) {
 	/* DMA : mbus clock gating */
 	setbits_le32(dma->bus_clk.gate_reg_base, BIT(dma->bus_clk.gate_reg_offset));
@@ -34,6 +74,12 @@ void sunxi_dma_clk_init(sunxi_dma_t *dma) {
 	setbits_le32(dma->dma_clk.gate_reg_base, BIT(dma->dma_clk.gate_reg_offset));
 }
 
+/**
+ * @brief Initialize the DMA controller
+ * @details Initializes the DMA controller by setting up registers, clearing interrupts,
+ *          configuring auto clock gating, and initializing channel structures.
+ * @param dma Pointer to DMA configuration structure containing base addresses and settings
+ */
 void sunxi_dma_init(sunxi_dma_t *dma) {
 	int i = 0;
 	sunxi_dma_reg_t *dma_reg = (sunxi_dma_reg_t *) dma->dma_reg_base;
@@ -45,18 +91,22 @@ void sunxi_dma_init(sunxi_dma_t *dma) {
 
 	sunxi_dma_clk_init(dma);
 
+	// Disable all interrupts
 	dma_reg->irq_en0 = 0;
 	dma_reg->irq_en1 = 0;
 
+	// Clear all pending interrupts
 	dma_reg->irq_pending0 = 0xffffffff;
 	dma_reg->irq_pending1 = 0xffffffff;
 
-	/* auto MCLK gating disable */
+	/* Disable auto MCLK gating */
 	dma_reg->auto_gate &= ~(0x7 << 0);
 	dma_reg->auto_gate |= 0x7 << 0;
 
+	// Initialize all channel sources to zero
 	memset((void *) dma_channel_source, 0, SUNXI_DMA_MAX * sizeof(sunxi_dma_source_t));
 
+	// Set up each DMA channel
 	for (i = 0; i < SUNXI_DMA_MAX; i++) {
 		dma_channel_source[i].used = 0;
 		dma_channel_source[i].channel = &(dma_reg->channel[i]);
@@ -65,15 +115,18 @@ void sunxi_dma_init(sunxi_dma_t *dma) {
 
 	dma_int_cnt = 0;
 	dma_init_ok = 1;
-
-	return;
 }
 
+/**
+ * @brief Exit and clean up DMA resources
+ * @details Releases all DMA channels, disables interrupts, and shuts down the DMA controller.
+ * @param dma Pointer to DMA configuration structure
+ */
 void sunxi_dma_exit(sunxi_dma_t *dma) {
 	uint32_t dma_fd;
 	sunxi_dma_reg_t *dma_reg = (sunxi_dma_reg_t *) dma->dma_reg_base;
 
-	/* free dma channel if other module not free it */
+	/* Free any DMA channels that haven't been released */
 	for (int i = 0; i < SUNXI_DMA_MAX; i++) {
 		if (dma_channel_source[i].used == 1) {
 			dma_channel_source[i].channel->enable = 0;
@@ -84,18 +137,27 @@ void sunxi_dma_exit(sunxi_dma_t *dma) {
 		}
 	}
 
-	/* close dma clock when dma exit */
+	/* Close DMA clock when exiting */
 	dma_reg->auto_gate &= ~(1 << dma->dma_clk.gate_reg_offset | 1 << dma->dma_clk.rst_reg_offset);
 
+	// Disable all interrupts
 	dma_reg->irq_en0 = 0;
 	dma_reg->irq_en1 = 0;
 
+	// Clear all pending interrupts
 	dma_reg->irq_pending0 = 0xffffffff;
 	dma_reg->irq_pending1 = 0xffffffff;
 
+	// Decrement initialization counter
 	dma_init_ok--;
 }
 
+/**
+ * @brief Request a DMA channel starting from the last available
+ * @details Searches for an available DMA channel starting from the highest-numbered channel.
+ * @param dmatype Type of DMA channel to request (currently unused)
+ * @return Handle to the requested DMA channel, or 0 if no channels are available
+ */
 uint32_t sunxi_dma_request_from_last(uint32_t dmatype) {
 	for (int i = SUNXI_DMA_MAX - 1; i >= 0; i--) {
 		if (dma_channel_source[i].used == 0) {
@@ -108,6 +170,12 @@ uint32_t sunxi_dma_request_from_last(uint32_t dmatype) {
 	return 0;
 }
 
+/**
+ * @brief Request a DMA channel
+ * @details Searches for an available DMA channel starting from channel 0.
+ * @param dmatype Type of DMA channel to request (currently unused)
+ * @return Handle to the requested DMA channel, or 0 if no channels are available
+ */
 uint32_t sunxi_dma_request(uint32_t dmatype) {
 	for (int i = 0; i < SUNXI_DMA_MAX; i++) {
 		if (dma_channel_source[i].used == 0) {
@@ -121,6 +189,12 @@ uint32_t sunxi_dma_request(uint32_t dmatype) {
 	return 0;
 }
 
+/**
+ * @brief Release a DMA channel
+ * @details Releases a previously requested DMA channel, disabling its interrupts.
+ * @param dma_fd Handle to the DMA channel to release
+ * @return 0 on success, -1 if the channel was not in use
+ */
 int sunxi_dma_release(uint32_t dma_fd) {
 	sunxi_dma_source_t *dma_source = (sunxi_dma_source_t *) dma_fd;
 
@@ -128,14 +202,24 @@ int sunxi_dma_release(uint32_t dma_fd) {
 		return -1;
 	}
 
+	// Disable and free interrupts
 	sunxi_dma_disable_int(dma_fd);
 	sunxi_dma_free_int(dma_fd);
 
+	// Mark channel as unused
 	dma_source->used = 0;
 
 	return 0;
 }
 
+/**
+ * @brief Configure DMA channel settings
+ * @details Sets up a DMA channel with specified configuration parameters like loop mode,
+ *          wait cycles, and data block size.
+ * @param dma_fd Handle to the DMA channel to configure
+ * @param cfg Pointer to configuration structure containing DMA settings
+ * @return 0 on success, -1 if the channel is not in use
+ */
 int sunxi_dma_setting(uint32_t dma_fd, sunxi_dma_set_t *cfg) {
 	uint32_t commit_para;
 	sunxi_dma_set_t *dma_set = cfg;
@@ -146,11 +230,13 @@ int sunxi_dma_setting(uint32_t dma_fd, sunxi_dma_set_t *cfg) {
 	if (!dma_source->used)
 		return -1;
 
+	// Configure descriptor link for loop mode
 	if (dma_set->loop_mode)
 		desc->link = (uint32_t) (&dma_source->desc);
 	else
 		desc->link = SUNXI_DMA_LINK_NULL;
 
+	// Set commit parameters
 	commit_para = (dma_set->wait_cyc & 0xff);
 	commit_para |= (dma_set->data_block_size & 0xff) << 8;
 
@@ -160,6 +246,15 @@ int sunxi_dma_setting(uint32_t dma_fd, sunxi_dma_set_t *cfg) {
 	return 0;
 }
 
+/**
+ * @brief Start a DMA transfer
+ * @details Initiates a DMA data transfer from source to destination address with specified size.
+ * @param dma_fd Handle to the DMA channel to use
+ * @param saddr Source address for the DMA transfer
+ * @param daddr Destination address for the DMA transfer
+ * @param bytes Number of bytes to transfer
+ * @return 0 on success, -1 if the channel is not in use
+ */
 int sunxi_dma_start(uint32_t dma_fd, uint32_t saddr, uint32_t daddr, uint32_t bytes) {
 	sunxi_dma_source_t *dma_source = (sunxi_dma_source_t *) dma_fd;
 	sunxi_dma_channel_reg_t *channel = dma_source->channel;
@@ -168,29 +263,43 @@ int sunxi_dma_start(uint32_t dma_fd, uint32_t saddr, uint32_t daddr, uint32_t by
 	if (!dma_source->used)
 		return -1;
 
-	/*config desc */
+	/* Configure descriptor */
 	desc->source_addr = saddr;
 	desc->dest_addr = daddr;
 	desc->byte_count = bytes;
 
-	/* start dma */
+	/* Start DMA transfer */
 	channel->desc_addr = (uint32_t) desc;
 	channel->enable = 1;
 
 	return 0;
 }
 
+/**
+ * @brief Stop a DMA transfer
+ * @details Halts an ongoing DMA transfer on the specified channel.
+ * @param dma_fd Handle to the DMA channel to stop
+ * @return 0 on success, -1 if the channel is not in use
+ */
 int sunxi_dma_stop(uint32_t dma_fd) {
 	sunxi_dma_source_t *dma_source = (sunxi_dma_source_t *) dma_fd;
 	sunxi_dma_channel_reg_t *channel = dma_source->channel;
 
 	if (!dma_source->used)
 		return -1;
+	
+	// Disable the channel
 	channel->enable = 0;
 
 	return 0;
 }
 
+/**
+ * @brief Query DMA transfer status
+ * @details Checks whether a DMA transfer is still in progress on the specified channel.
+ * @param dma_fd Handle to the DMA channel to query
+ * @return 1 if transfer is in progress, 0 if completed, -1 if channel is not in use
+ */
 int sunxi_dma_querystatus(uint32_t dma_fd) {
 	uint32_t channel_count;
 	sunxi_dma_source_t *dma_source = (sunxi_dma_source_t *) dma_fd;
@@ -201,9 +310,17 @@ int sunxi_dma_querystatus(uint32_t dma_fd) {
 
 	channel_count = dma_source->channel_count;
 
+	// Return the status bit for this channel
 	return (dma_reg->status >> channel_count) & 0x01;
 }
 
+/**
+ * @brief Install interrupt handler for DMA channel
+ * @details Sets up an interrupt handler for a DMA channel and clears any pending interrupts.
+ * @param dma_fd Handle to the DMA channel
+ * @param p User data to associate with the interrupt handler
+ * @return 0 on success, -1 if channel is not in use
+ */
 int sunxi_dma_install_int(uint32_t dma_fd, void *p) {
 	sunxi_dma_source_t *dma_source = (sunxi_dma_source_t *) dma_fd;
 	sunxi_dma_reg_t *dma_reg = (sunxi_dma_reg_t *) DMA_REG_BASE;
@@ -214,11 +331,13 @@ int sunxi_dma_install_int(uint32_t dma_fd, void *p) {
 
 	channel_count = dma_source->channel_count;
 
+	// Clear pending interrupts for this channel
 	if (channel_count < 8)
 		dma_reg->irq_pending0 = (7 << channel_count * 4);
 	else
 		dma_reg->irq_pending1 = (7 << (channel_count - 8) * 4);
 
+	// Set up interrupt function if not already set
 	if (!dma_source->dma_func.m_func) {
 		dma_source->dma_func.m_func = 0;
 		dma_source->dma_func.m_data = p;
@@ -229,6 +348,12 @@ int sunxi_dma_install_int(uint32_t dma_fd, void *p) {
 	return 0;
 }
 
+/**
+ * @brief Enable interrupts for a DMA channel
+ * @details Enables interrupts for a specific DMA channel, specifically package end interrupts.
+ * @param dma_fd Handle to the DMA channel
+ * @return 0 on success, -1 if channel is not in use
+ */
 int sunxi_dma_enable_int(uint32_t dma_fd) {
 	sunxi_dma_source_t *dma_source = (sunxi_dma_source_t *) dma_fd;
 	sunxi_dma_reg_t *dma_reg = (sunxi_dma_reg_t *) DMA_REG_BASE;
@@ -239,24 +364,35 @@ int sunxi_dma_enable_int(uint32_t dma_fd) {
 
 	channel_count = dma_source->channel_count;
 	if (channel_count < 8) {
+		// Check if interrupt is already enabled
 		if ((dma_reg->irq_en0) & (DMA_PKG_END_INT << channel_count * 4)) {
-			printk_debug("DMA: 0x%08x int is avaible already\n", dma_fd);
+			printk_debug("DMA: 0x%08x int is available already\n", dma_fd);
 			return 0;
 		}
+		// Enable package end interrupt for this channel
 		dma_reg->irq_en0 |= (DMA_PKG_END_INT << channel_count * 4);
 	} else {
+		// Check if interrupt is already enabled
 		if ((dma_reg->irq_en1) & (DMA_PKG_END_INT << (channel_count - 8) * 4)) {
-			printk_debug("DMA: 0x%08x int is avaible already\n", dma_fd);
+			printk_debug("DMA: 0x%08x int is available already\n", dma_fd);
 			return 0;
 		}
+		// Enable package end interrupt for this channel
 		dma_reg->irq_en1 |= (DMA_PKG_END_INT << (channel_count - 8) * 4);
 	}
 
+	// Increment interrupt count
 	dma_int_cnt++;
 
 	return 0;
 }
 
+/**
+ * @brief Disable interrupts for a DMA channel
+ * @details Disables interrupts for a specific DMA channel.
+ * @param dma_fd Handle to the DMA channel
+ * @return 0 on success, -1 if channel is not in use
+ */
 int sunxi_dma_disable_int(uint32_t dma_fd) {
 	sunxi_dma_source_t *dma_source = (sunxi_dma_source_t *) dma_fd;
 	sunxi_dma_reg_t *dma_reg = (sunxi_dma_reg_t *) DMA_REG_BASE;
@@ -267,26 +403,36 @@ int sunxi_dma_disable_int(uint32_t dma_fd) {
 
 	channel_count = dma_source->channel_count;
 	if (channel_count < 8) {
+		// Check if interrupt is not enabled
 		if (!((dma_reg->irq_en0) & (DMA_PKG_END_INT << channel_count * 4))) {
 			printk_debug("DMA: 0x%08x int is not used yet\n", dma_fd);
 			return 0;
 		}
+		// Disable package end interrupt for this channel
 		dma_reg->irq_en0 &= ~(DMA_PKG_END_INT << channel_count * 4);
 	} else {
+		// Check if interrupt is not enabled
 		if (!((dma_reg->irq_en1) & (DMA_PKG_END_INT << (channel_count - 8) * 4))) {
 			printk_debug("DMA: 0x%08x int is not used yet\n", dma_fd);
 			return 0;
 		}
+		// Disable package end interrupt for this channel
 		dma_reg->irq_en1 &= ~(DMA_PKG_END_INT << (channel_count - 8) * 4);
 	}
 
-	/* disable golbal int */
+	/* Decrement interrupt count */
 	if (dma_int_cnt > 0)
 		dma_int_cnt--;
 
 	return 0;
 }
 
+/**
+ * @brief Free interrupt handler for a DMA channel
+ * @details Releases the interrupt handler associated with a DMA channel and clears pending interrupts.
+ * @param dma_fd Handle to the DMA channel
+ * @return 0 on success, -1 if channel is not in use or interrupt handler was not set
+ */
 int sunxi_dma_free_int(uint32_t dma_fd) {
 	sunxi_dma_source_t *dma_source = (sunxi_dma_source_t *) dma_fd;
 	sunxi_dma_reg_t *dma_reg = (sunxi_dma_reg_t *) DMA_REG_BASE;
@@ -296,11 +442,13 @@ int sunxi_dma_free_int(uint32_t dma_fd) {
 		return -1;
 
 	channel_count = dma_source->channel_count;
+	// Clear pending interrupts
 	if (channel_count < 8)
 		dma_reg->irq_pending0 = (7 << channel_count);
 	else
 		dma_reg->irq_pending1 = (7 << (channel_count - 8));
 
+	// Free the interrupt handler if set
 	if (dma_source->dma_func.m_func) {
 		dma_source->dma_func.m_func = NULL;
 		dma_source->dma_func.m_data = NULL;
@@ -312,7 +460,15 @@ int sunxi_dma_free_int(uint32_t dma_fd) {
 	return 0;
 }
 
-
+/**
+ * @brief Test DMA functionality
+ * @details Performs a DMA transfer test between two memory regions, verifies data integrity,
+ *          and reports transfer performance.
+ * @param src_addr Source memory address for test transfer
+ * @param dst_addr Destination memory address for test transfer
+ * @param len Length of data to transfer in bytes
+ * @return 0 on success, -1 if channel request failed, -2 if transfer timed out
+ */
 int sunxi_dma_test(uint32_t *src_addr, uint32_t *dst_addr, uint32_t len) {
 	sunxi_dma_set_t dma_set;
 	uint32_t st = 0;
@@ -320,35 +476,39 @@ int sunxi_dma_test(uint32_t *src_addr, uint32_t *dst_addr, uint32_t len) {
 	uint32_t dma_fd;
 	uint32_t i, valid;
 
+	// Align length to 4-byte boundary
 	len = ALIGN(len, 4);
 	printk_debug("DMA: test 0x%08x ====> 0x%08x, len %uKB \n", (uint32_t) src_addr, (uint32_t) dst_addr, (len / 1024));
 
-	/* dma */
+	/* Configure DMA settings */
 	dma_set.loop_mode = 0;
 	dma_set.wait_cyc = 8;
 	dma_set.data_block_size = 1 * 32 / 8;
-	/* channel config (from dram to dram)*/
-	dma_set.channel_cfg.src_drq_type = DMAC_CFG_TYPE_DRAM;// dram
+	
+	/* Channel configuration (DRAM to DRAM transfer) */
+	dma_set.channel_cfg.src_drq_type = DMAC_CFG_TYPE_DRAM; // DRAM source
 	dma_set.channel_cfg.src_addr_mode = DMAC_CFG_DEST_ADDR_TYPE_LINEAR_MODE;
 	dma_set.channel_cfg.src_burst_length = DMAC_CFG_SRC_4_BURST;
 	dma_set.channel_cfg.src_data_width = DMAC_CFG_SRC_DATA_WIDTH_16BIT;
 	dma_set.channel_cfg.reserved0 = 0;
 
-	dma_set.channel_cfg.dst_drq_type = DMAC_CFG_TYPE_DRAM;// dram
+	dma_set.channel_cfg.dst_drq_type = DMAC_CFG_TYPE_DRAM; // DRAM destination
 	dma_set.channel_cfg.dst_addr_mode = DMAC_CFG_DEST_ADDR_TYPE_LINEAR_MODE;
 	dma_set.channel_cfg.dst_burst_length = DMAC_CFG_DEST_4_BURST;
 	dma_set.channel_cfg.dst_data_width = DMAC_CFG_DEST_DATA_WIDTH_16BIT;
 	dma_set.channel_cfg.reserved1 = 0;
 
+	// Request a DMA channel
 	dma_fd = sunxi_dma_request(0);
 	if (!dma_fd) {
 		printk_error("DMA: can't request dma\n");
 		return -1;
 	}
 
+	// Configure the DMA channel
 	sunxi_dma_setting(dma_fd, &dma_set);
 
-	// prepare data
+	// Prepare test data
 	for (i = 0; i < (len / 4); i += 4) {
 		src_addr[i] = i;
 		src_addr[i + 1] = i + 1;
@@ -356,36 +516,44 @@ int sunxi_dma_test(uint32_t *src_addr, uint32_t *dst_addr, uint32_t len) {
 		src_addr[i + 3] = i + 3;
 	}
 
-	/* timeout : 100 ms */
+	/* Set timeout to 100 ms */
 	timeout = time_ms();
 
+	// Start the DMA transfer
 	sunxi_dma_start(dma_fd, (uint32_t) src_addr, (uint32_t) dst_addr, len);
 	st = sunxi_dma_querystatus(dma_fd);
 
-	while ((time_ms() - timeout < 100) && st) { st = sunxi_dma_querystatus(dma_fd); }
+	// Wait for transfer to complete or timeout
+	while ((time_ms() - timeout < 100) && st) { 
+		st = sunxi_dma_querystatus(dma_fd); 
+	}
 
 	if (st) {
+		// Transfer timed out
 		printk_error("DMA: test timeout!\n");
 		sunxi_dma_stop(dma_fd);
 		sunxi_dma_release(dma_fd);
-
 		return -2;
 	} else {
+		// Verify data integrity
 		valid = 1;
 		printk_debug("DMA: test done in %lums\n", (time_ms() - timeout));
-		// Check data is valid
+		
 		for (i = 0; i < (len / 4); i += 4) {
-			if (dst_addr[i] != i || dst_addr[i + 1] != i + 1 || dst_addr[i + 2] != i + 2 || dst_addr[i + 3] != i + 3) {
+			if (dst_addr[i] != i || dst_addr[i + 1] != i + 1 || 
+			    dst_addr[i + 2] != i + 2 || dst_addr[i + 3] != i + 3) {
 				valid = 0;
 				break;
 			}
 		}
+		
 		if (valid)
 			printk_debug("DMA: test check valid\n");
 		else
 			printk_error("DMA: test check failed at %u bytes\n", i);
 	}
 
+	// Clean up
 	sunxi_dma_stop(dma_fd);
 	sunxi_dma_release(dma_fd);
 

--- a/src/drivers/sys-dram.c
+++ b/src/drivers/sys-dram.c
@@ -1,5 +1,13 @@
 /* SPDX-License-Identifier: GPL-2.0+ */
 
+/**
+ * @file sys-dram.c
+ * @brief System DRAM (Dynamic Random Access Memory) driver for Allwinner (sunxi) platforms
+ * @details This file provides weak implementations for DRAM-related functions that
+ *          can be overridden by platform-specific implementations. These functions
+ *          handle DRAM initialization and size detection for Allwinner SoCs.
+ */
+
 #include <io.h>
 #include <stdarg.h>
 #include <stdbool.h>
@@ -9,10 +17,27 @@
 
 #include <log.h>
 
+/**
+ * @brief Get the total DRAM size
+ * @details This weak function returns the total size of the system DRAM in bytes.
+ *          Platform-specific implementations should override this function to return
+ *          the actual DRAM size detected for the specific SoC and board configuration.
+ * @return Total DRAM size in bytes. Default implementation returns 0.
+ */
 uint64_t __attribute__((weak)) sunxi_get_dram_size() {
 	return 0;
 }
 
+/**
+ * @brief Initialize DRAM controller and memory
+ * @details This weak function initializes the DRAM controller and configures memory settings.
+ *          Platform-specific implementations should override this function to perform
+ *          SoC-specific DRAM initialization including timing configuration, voltage setup,
+ *          and memory training.
+ * @param para Pointer to initialization parameters. The exact structure depends on the
+ *             platform implementation.
+ * @return 0 on success, non-zero error code on failure. Default implementation returns 0.
+ */
 uint32_t __attribute__((weak)) sunxi_dram_init(void *para) {
 	return 0;
 }

--- a/src/drivers/sys-pwm.c
+++ b/src/drivers/sys-pwm.c
@@ -1,5 +1,16 @@
 /* SPDX-License-Identifier: GPL-2.0+ */
 
+/**
+ * @file sys-pwm.c
+ * @brief System PWM (Pulse Width Modulation) driver for Allwinner (sunxi) platforms
+ * @details This file implements PWM functionality for Allwinner SoCs, supporting
+ *          multiple channels with configurable frequency, duty cycle, polarity,
+ *          and dead zone timing. It provides both single-channel and dual-channel
+ *          binding modes, with support for pulse mode operations.
+ *          The driver handles various clock sources including APB and oscillator
+ *          clocks, and provides fine-grained control over PWM output parameters.
+ */
+
 #include <io.h>
 #include <stdarg.h>
 #include <stdbool.h>

--- a/src/drivers/sys-rtc.c
+++ b/src/drivers/sys-rtc.c
@@ -1,5 +1,17 @@
 /* SPDX-License-Identifier: GPL-2.0+ */
 
+/**
+ * @file sys-rtc.c
+ * @brief System RTC (Real-Time Clock) driver for Allwinner (sunxi) platforms
+ * @details This file implements RTC functionality for Allwinner SoCs, providing
+ *          interface functions to read from and write to RTC registers. The RTC
+ *          is used to store various persistent flags and parameters, including
+ *          FEL (Fastboot External Loader) mode flag, boot mode information,
+ *          DRAM parameters, and initialization timestamp. These values are
+ *          retained even when the system is powered off, as long as there is
+ *          backup battery power.
+ */
+
 #include <io.h>
 #include <log.h>
 #include <mmu.h>
@@ -16,28 +28,30 @@
 #include <sys-rtc.h>
 
 /**
- * Write data to the RTC register at the specified index.
- *
- * @param index The index of the RTC register to write data to.
- * @param val The value to write to the RTC register.
+ * @brief Write data to an RTC register
+ * @details Writes a 32-bit value to the RTC register at the specified index.
+ * @param index The index of the RTC register to write data to
+ * @param val The value to write to the RTC register
  */
 void rtc_write_data(int index, uint32_t val) {
 	writel(val, SUNXI_RTC_DATA_BASE + index * 4);
 }
 
 /**
- * Read data from the RTC register at the specified index.
- *
- * @param index The index of the RTC register to read data from.
- * @return The value read from the RTC register.
+ * @brief Read data from an RTC register
+ * @details Reads a 32-bit value from the RTC register at the specified index.
+ * @param index The index of the RTC register to read data from
+ * @return The value read from the RTC register
  */
 uint32_t rtc_read_data(int index) {
 	return readl(SUNXI_RTC_DATA_BASE + index * 4);
 }
 
 /**
- * Set the FEL (Fastboot External Loader) flag in the RTC register.
- * This flag indicates that the system should enter Fastboot mode.
+ * @brief Set the FEL (Fastboot External Loader) flag
+ * @details Sets the FEL flag in the RTC register, which indicates that the system
+ *          should enter Fastboot mode. The function verifies the write operation
+ *          was successful by reading back the value.
  */
 void rtc_set_fel_flag(void) {
 	do {
@@ -47,8 +61,10 @@ void rtc_set_fel_flag(void) {
 }
 
 /**
- * Set the start time in milliseconds in the RTC register.
- * This function sets the start time for a specific operation.
+ * @brief Set the initialization timestamp
+ * @details Stores the initialization timestamp (in milliseconds) in the RTC register.
+ *          This value can be used for timing operations or to determine the system
+ *          uptime. The function verifies the write operation was successful.
  */
 void rtc_set_start_time_ms(void) {
 	uint32_t init_time_ms = get_init_timestamp();
@@ -77,17 +93,18 @@ void rtc_set_dram_para(uint32_t dram_para_addr) {
 }
 
 /**
- * Probe the FEL (Fastboot External Loader) flag in the RTC register.
- *
- * @return The value of the FEL flag (0 or 1).
+ * @brief Check if the FEL flag is set
+ * @details Reads the FEL flag from the RTC register and returns whether it is set.
+ * @return 1 if the FEL flag is set, 0 otherwise
  */
 uint32_t rtc_probe_fel_flag(void) {
 	return rtc_read_data(RTC_FEL_INDEX) == EFEX_FLAG ? 1 : 0;
 }
 
 /**
- * Clear the FEL (Fastboot External Loader) flag in the RTC register.
- * This function clears the FEL flag after it has been processed.
+ * @brief Clear the FEL (Fastboot External Loader) flag
+ * @details Clears the FEL flag in the RTC register after it has been processed.
+ *          The function verifies the write operation was successful by reading back the value.
  */
 void rtc_clear_fel_flag(void) {
 	do {
@@ -97,10 +114,11 @@ void rtc_clear_fel_flag(void) {
 }
 
 /**
- * Set the bootmode flag in the RTC register.
- *
- * @param flag The bootmode flag value to set.
- * @return 0 if successful, or an error code if failed.
+ * @brief Set the boot mode flag
+ * @details Sets the boot mode flag in the RTC register, which determines how the
+ *          system will boot. The function verifies the write operation was successful.
+ * @param flag The boot mode flag value to set
+ * @return 0 if successful
  */
 int rtc_set_bootmode_flag(uint8_t flag) {
 	do {
@@ -112,9 +130,11 @@ int rtc_set_bootmode_flag(uint8_t flag) {
 }
 
 /**
- * Get the bootmode flag from the RTC register.
- *
- * @return The value of the bootmode flag.
+ * @brief Get the boot mode flag
+ * @details Reads the boot mode flag from the RTC register. This is used to determine
+ *          how the system should boot. The operation is designed to be compatible
+ *          with how the kernel reads this value.
+ * @return The value of the boot mode flag
  */
 int rtc_get_bootmode_flag(void) {
 	uint32_t boot_flag;

--- a/src/drivers/sys-spi.c
+++ b/src/drivers/sys-spi.c
@@ -1,4 +1,21 @@
-/* SPDX-License-Identifier: GPL-2.0+ */
+/**
+ * @file sys-spi.c
+ * @brief Allwinner Platform SPI Controller Driver
+ *
+ * This file implements the SPI (Serial Peripheral Interface) controller driver
+ * for Allwinner platforms. The SPI driver provides functionality for initializing
+ * and controlling the SPI interface, including clock configuration, data transfer,
+ * GPIO setup, and DMA operations. It supports various SPI modes, data widths,
+ * and transfer methods (polling and DMA).
+ *
+ * The driver supports different I/O modes including single, dual, and quad SPI,
+ * making it suitable for interfacing with various SPI devices such as flash memory,
+ * sensors, and other peripheral devices.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Copyright (c) 2023, Allwinner Technology Co., Ltd.
+ */
 
 #if LOG_LEVEL_DEFAULT <= LOG_LEVEL_DEBUG
 /* #define LOG_LEVEL_DEFAULT LOG_LEVEL_DEBUG */

--- a/src/drivers/sys-trng.c
+++ b/src/drivers/sys-trng.c
@@ -1,4 +1,14 @@
-/* SPDX-License-Identifier: GPL-2.0+ */
+/**
+ * @file sys-trng.c
+ * @brief Allwinner Platform True Random Number Generator (TRNG) Driver
+ *
+ * This file implements the True Random Number Generator driver for Allwinner platforms.
+ * The TRNG driver provides functionality for generating cryptographically secure
+ * random numbers from hardware entropy sources. This is essential for security-related
+ * operations such as key generation, encryption initialization vectors, and secure
+ * random values for various cryptographic protocols.
+ *
+ * SPDX-License-Identifier: GPL-2.0+ */
 
 #include <io.h>
 #include <stdarg.h>

--- a/src/drivers/sys-uart.c
+++ b/src/drivers/sys-uart.c
@@ -1,4 +1,13 @@
-/* SPDX-License-Identifier: GPL-2.0+ */
+/**
+ * @file sys-uart.c
+ * @brief Allwinner Platform UART (Universal Asynchronous Receiver/Transmitter) Driver
+ *
+ * This file implements the UART driver for Allwinner platforms. The UART driver provides
+ * functionality for serial communication, including initialization, configuration,
+ * and basic input/output operations. It supports various UART settings such as baud rate,
+ * parity, stop bits, and data length.
+ *
+ * SPDX-License-Identifier: GPL-2.0+ */
 
 #include <stdarg.h>
 #include <stdbool.h>
@@ -14,6 +23,14 @@
 
 #include <sys-clk.h>
 
+/**
+ * @brief Initialize the UART clock
+ * 
+ * This function configures the UART clock by setting the reset control and enabling
+ * the clock gate for the UART module. It prepares the UART hardware for further configuration.
+ *
+ * @param[in] uart Pointer to the UART structure containing clock configuration
+ */
 void sunxi_serial_clock_init(sunxi_serial_t *uart) {
 	sunxi_clk_t uart_clk = uart->uart_clk;
 	/* Set CLK RST */
@@ -24,6 +41,16 @@ void sunxi_serial_clock_init(sunxi_serial_t *uart) {
 	setbits_le32(uart_clk.gate_reg_base, BIT(uart_clk.gate_reg_offset));
 }
 
+/**
+ * @brief Initialize the UART interface
+ * 
+ * This function initializes the UART interface by configuring the clock, baud rate,
+ * line control settings (parity, stop bits, data length), FIFO control, and GPIO pins.
+ * It sets up the UART for serial communication based on the provided configuration.
+ *
+ * @param[in] uart Pointer to the UART structure containing complete configuration
+ *                 including base address, clock settings, baud rate, and GPIO pins
+ */
 void sunxi_serial_init(sunxi_serial_t *uart) {
 	sunxi_serial_clock_init(uart);
 
@@ -72,6 +99,15 @@ void sunxi_serial_init(sunxi_serial_t *uart) {
 	sunxi_gpio_init(uart->gpio_pin.gpio_rx.pin, uart->gpio_pin.gpio_rx.mux);
 }
 
+/**
+ * @brief Output a character to the UART
+ * 
+ * This function sends a single character to the UART transmit buffer. It waits until
+ * the transmit holding register is empty before writing the character.
+ *
+ * @param[in] arg Pointer to the UART structure (cast to void* for compatibility)
+ * @param[in] c The character to be transmitted
+ */
 void __attribute__((weak)) sunxi_serial_putc(void *arg, char c) {
 	sunxi_serial_t *uart = (sunxi_serial_t *) arg;
 	sunxi_serial_reg_t *serial_reg = (sunxi_serial_reg_t *) uart->base;
@@ -81,6 +117,15 @@ void __attribute__((weak)) sunxi_serial_putc(void *arg, char c) {
 	serial_reg->thr = c;
 }
 
+/**
+ * @brief Read a character from the UART
+ * 
+ * This function reads a single character from the UART receive buffer. It waits until
+ * data is available before reading.
+ *
+ * @param[in] arg Pointer to the UART structure (cast to void* for compatibility)
+ * @return The received character
+ */
 char __attribute__((weak)) sunxi_serial_getc(void *arg) {
 	sunxi_serial_t *uart = (sunxi_serial_t *) arg;
 	sunxi_serial_reg_t *serial_reg = (sunxi_serial_reg_t *) uart->base;
@@ -90,6 +135,15 @@ char __attribute__((weak)) sunxi_serial_getc(void *arg) {
 	return serial_reg->rbr;
 }
 
+/**
+ * @brief Check if a character is available to read from the UART
+ * 
+ * This function checks the UART line status register to determine if there is
+ * data available in the receive buffer.
+ *
+ * @param[in] arg Pointer to the UART structure (cast to void* for compatibility)
+ * @return Non-zero value if data is available, zero otherwise
+ */
 int __attribute__((weak)) sunxi_serial_tstc(void *arg) {
 	sunxi_serial_t *uart = (sunxi_serial_t *) arg;
 	sunxi_serial_reg_t *serial_reg = (sunxi_serial_reg_t *) uart->base;


### PR DESCRIPTION
Add comprehensive documentation blocks to all Allwinner platform drivers including:
- File descriptions explaining purpose and functionality
- Detailed function documentation with parameters and return values
- Constants and macro definitions
- Important implementation details
- Configuration options and usage examples

The documentation follows standard kernel-doc format and provides complete API references for TRNG, PWM, SPI, DRAM, CLK, UART, RTC, I2C, and DMA drivers.