### PR TITLE
feat(rust): implement embedded-hal digital traits for GpioPin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,7 @@ jobs:
           file tools/bin/dt2c | grep -F 'static-pie linked'
           ! readelf -d tools/bin/dt2c | grep -q '(NEEDED)'
           rustup toolchain install stable --profile minimal
+          rustup target add --toolchain stable riscv32imac-unknown-none-elf
           source_build="${RUNNER_TEMP}/dt2c-source-build"
           make O="${source_build}" \
             DT2C="${source_build}/.obj/tools/dt2c/release/dt2c" \

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -70,6 +70,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
+name = "embedded-hal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+
+[[package]]
 name = "glob"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +227,7 @@ dependencies = [
 name = "syterkit-drivers"
 version = "0.1.0"
 dependencies = [
+ "embedded-hal",
  "syterkit-ffi",
  "syterkit-lib",
 ]

--- a/rust/drivers/Cargo.toml
+++ b/rust/drivers/Cargo.toml
@@ -11,5 +11,6 @@ build = "build.rs"
 crate-type = ["rlib"]
 
 [dependencies]
+embedded-hal = "1.0.0"
 syterkit-ffi = { path = "../ffi" }
 syterkit-lib = { path = "../lib" }

--- a/rust/drivers/src/gpio.rs
+++ b/rust/drivers/src/gpio.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0+
 
-use core::marker::PhantomData;
-
+use core::{convert::Infallible, marker::PhantomData};
+use embedded_hal::digital::{ErrorType, InputPin, OutputPin, PinState};
 use syterkit_ffi::raw;
 #[cfg(syterkit_config_driver_gpio_v2_pow)]
 use syterkit_lib::{DriverResult, INVALID_ARGUMENT};
@@ -77,29 +77,6 @@ impl GpioPin {
         unsafe { raw::sunxi_gpio_init(&self.raw) };
     }
 
-    /// Set the output level.
-    pub fn set_level(&self, high: bool) {
-        let value = if high {
-            raw::GPIO_LEVEL_HIGH
-        } else {
-            raw::GPIO_LEVEL_LOW
-        };
-        unsafe { raw::sunxi_gpio_set_value(&self.raw, value as i32) };
-    }
-
-    pub fn set_high(&self) {
-        self.set_level(true);
-    }
-
-    pub fn set_low(&self) {
-        self.set_level(false);
-    }
-
-    /// Read the current digital level.
-    pub fn is_high(&self) -> bool {
-        unsafe { raw::sunxi_gpio_read(&self.raw) != 0 }
-    }
-
     pub fn set_pull(&self, pull: GpioPull) {
         unsafe { raw::sunxi_gpio_set_pull(&self.raw, pull.into_raw()) };
     }
@@ -127,11 +104,45 @@ impl GpioPin {
     }
 }
 
+impl ErrorType for GpioPin {
+    type Error = Infallible;
+}
+
+impl InputPin for GpioPin {
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(unsafe { raw::sunxi_gpio_read(&self.raw) != 0 })
+    }
+
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(unsafe { raw::sunxi_gpio_read(&self.raw) == 0 })
+    }
+}
+
+impl OutputPin for GpioPin {
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.set_state(PinState::Low)
+    }
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.set_state(PinState::High)
+    }
+
+    fn set_state(&mut self, state: PinState) -> Result<(), Self::Error> {
+        let value = match state {
+            PinState::Low => raw::GPIO_LEVEL_LOW,
+            PinState::High => raw::GPIO_LEVEL_HIGH,
+        };
+        unsafe { raw::sunxi_gpio_set_value(&self.raw, value as i32) };
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{GpioPin, GpioPull, GPIO};
     use core::ffi::c_int;
     use core::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, Ordering};
+    use embedded_hal::digital::{InputPin, OutputPin, StatefulOutputPin};
     use std::sync::Mutex;
 
     static TEST_LOCK: Mutex<()> = Mutex::new(());
@@ -206,18 +217,18 @@ mod tests {
         GPIO_DRIVE.store(0, Ordering::Relaxed);
 
         GPIO.initialize_power_mode();
-        let pin = unsafe { GpioPin::new(0x1000, 7, 2, 1) };
+        let mut pin = unsafe { GpioPin::new(0x1000, 7, 2, 1) };
         pin.initialize();
         pin.set_pull(GpioPull::Down);
         pin.set_drive_strength(3);
-        pin.set_high();
+        pin.set_high().ok();
 
         assert!(GPIO_INITIALIZED.load(Ordering::Relaxed));
         assert_eq!(GPIO_PULL.load(Ordering::Relaxed), 1);
         assert_eq!(GPIO_DRIVE.load(Ordering::Relaxed), 3);
-        assert!(pin.is_high());
-        pin.set_low();
-        assert!(!pin.is_high());
+        assert!(pin.is_high().unwrap());
+        pin.set_low().ok();
+        assert!(!pin.is_high().unwrap());
 
         #[cfg(syterkit_config_driver_gpio_v2_pow)]
         {


### PR DESCRIPTION
`embedded-hal` is a mature Rust embedded library for embedded peripheral abstractions.

Add embedded-hal 1.0 as a driver dependency and implement the digital input and output traits for GpioPin. Update GPIO tests to exercise the trait-based interface.
