### PR TITLE
fix(c907): initialize caches for I-cache-only configurations

### DIFF
--- a/arch/riscv/cpu/c907/cache.c
+++ b/arch/riscv/cpu/c907/cache.c
@@ -35,7 +35,7 @@ void data_sync_barrier(void)
 void cache_init(void)
 {
 	csr_write(mcor, 0x70013);
-	csr_write(mhcr, 0x11ff);
+	csr_write(mhcr, 0x11ff & ~(MHCR_IE | MHCR_DE));
 	csr_set(mxstatus, 0x638000);
 	csr_write(mhint, 0x16e30c);
 }

--- a/arch/riscv/cpu/c907/start.S
+++ b/arch/riscv/cpu/c907/start.S
@@ -63,11 +63,15 @@ _start:
 
 	jal set_timer_count
 
-#ifdef CONFIG_ARCH_DCACHE
+#if defined(CONFIG_ARCH_ICACHE) || defined(CONFIG_ARCH_DCACHE)
 	jal cache_init
+#endif
 
+#ifdef CONFIG_ARCH_ICACHE
 	jal icache_enable
+#endif
 
+#ifdef CONFIG_ARCH_DCACHE
 	jal dcache_enable
 #endif
 

--- a/boards/yuzukineko/app_sram/spinor-boot-rv64i/main.c
+++ b/boards/yuzukineko/app_sram/spinor-boot-rv64i/main.c
@@ -5,12 +5,12 @@
  *
  * This is the RV64 handoff variant of spinor-boot. The SPL itself is linked
  * as RV32 because the C907 starts in RV32 mode. After loading the payloads
- * from SPI NOR, it resets the core into RV64 and enters OpenSBI in PSRAM.
+ * from SPI NOR, it resets the core into RV64 and enters SBI firmware in PSRAM.
  *
  * SPI NOR layout (all offsets are 2 KiB aligned):
  *	0x000000  bootloader   (this image, eGON BT0, up to 64 KiB)
  *	0x010000  device tree  (<= 256 KiB)
- *	0x050000  fw_jump.bin  (OpenSBI, 512 KiB)
+ *	0x050000  fw_jump.bin  (SBI firmware, 512 KiB)
  *	0x0d0000  Image        (Linux kernel, up to 6 MiB)
  *	0x6d0000  root filesystem
  */
@@ -41,17 +41,17 @@
 #define F101_RAM_SIZE		0x01000000U
 
 /*
- * PSRAM reservations, bottom up: Linux Image, then DTB, then OpenSBI pinned
+ * PSRAM reservations, bottom up: Linux Image, then DTB, then SBI firmware pinned
  * at the top of PSRAM. The heap for the SPIF sampling training lives in the
  * gap between the kernel region and the DTB reservation.
  */
 #define F101_KERNEL_SIZE	0x00600000U	/* Linux Image up to 6 MiB */
 #define F101_DTB_SIZE		0x00040000U	/* Device tree up to 256 KiB */
-#define F101_OPENSBI_SIZE	0x00080000U	/* OpenSBI fw_jump 512 KiB */
+#define F101_SBI_SIZE	0x00080000U	/* SBI firmware fw_jump 512 KiB */
 
 #define F101_LINUX_ADDR		(F101_RAM_BASE)
-#define F101_OPENSBI_ADDR	(F101_RAM_BASE + F101_RAM_SIZE - F101_OPENSBI_SIZE)
-#define F101_DTB_ADDR		(F101_OPENSBI_ADDR - F101_DTB_SIZE)
+#define F101_SBI_ADDR	(F101_RAM_BASE + F101_RAM_SIZE - F101_SBI_SIZE)
+#define F101_DTB_ADDR		(F101_SBI_ADDR - F101_DTB_SIZE)
 
 #define F101_HEAP_BASE		(F101_LINUX_ADDR + F101_KERNEL_SIZE)
 #define F101_HEAP_SIZE		(F101_DTB_ADDR - F101_HEAP_BASE)
@@ -60,18 +60,18 @@
 #define F101_BOOT_SIZE		0x00010000U
 
 #define F101_NOR_DTB_OFFSET		F101_BOOT_SIZE
-#define F101_NOR_OPENSBI_OFFSET		(F101_NOR_DTB_OFFSET + F101_DTB_SIZE)
-#define F101_NOR_KERNEL_OFFSET		(F101_NOR_OPENSBI_OFFSET + F101_OPENSBI_SIZE)
+#define F101_NOR_SBI_OFFSET		(F101_NOR_DTB_OFFSET + F101_DTB_SIZE)
+#define F101_NOR_KERNEL_OFFSET		(F101_NOR_SBI_OFFSET + F101_SBI_SIZE)
 
 /*
  * This entry is executed after the C907 has been reset into RV64 mode. It
  * must stay as raw instructions because this application itself is linked as
- * RV32. The reset vector points here, then the stub supplies the OpenSBI
+ * RV32. The reset vector points here, then the stub supplies the SBI firmware
  * arguments before jumping to fw_jump in PSRAM.
  *
  *	0x00000513  addi a0, zero, 0
  *	0x40f405b7  lui  a1, 0x40f40       (F101_DTB_ADDR)
- *	0x40f802b7  lui  t0, 0x40f80       (F101_OPENSBI_ADDR)
+ *	0x40f802b7  lui  t0, 0x40f80       (F101_SBI_ADDR)
  *	0x0000100f  fence.i
  *	0x00028067  jr   t0
  */
@@ -124,7 +124,7 @@ static int f101_validate_dtb(void)
 	return 0;
 }
 
-static __attribute__((noreturn, noinline)) void f101_boot_opensbi(void)
+static __attribute__((noreturn, noinline)) void f101_boot_sbi_firmware(void)
 {
 	uintptr_t rv64_entry = (uintptr_t)f101_rv64_entry;
 
@@ -135,7 +135,7 @@ static __attribute__((noreturn, noinline)) void f101_boot_opensbi(void)
 	/*
 	 * C907 latches the ISA mode at reset. Program the reset vector and force
 	 * RV64, then use the RISC-V watchdog to restart the core. The reset lands
-	 * in f101_rv64_entry, which sets a0/a1 and jumps to OpenSBI.
+	 * in f101_rv64_entry, which sets a0/a1 and jumps to SBI firmware.
 	 */
 	asm volatile(
 		"li t0, 0x02001d0c\n\t"
@@ -215,8 +215,8 @@ static int f101_load_images(spif_nor_t *nor)
 			       F101_DTB_ADDR, F101_DTB_SIZE) != 0)
 		return -1;
 
-	if (f101_read_from_nor(nor, "fw_jump", F101_NOR_OPENSBI_OFFSET,
-			       F101_OPENSBI_ADDR, F101_OPENSBI_SIZE) != 0)
+	if (f101_read_from_nor(nor, "fw_jump", F101_NOR_SBI_OFFSET,
+			       F101_SBI_ADDR, F101_SBI_SIZE) != 0)
 		return -1;
 
 	if (f101_read_from_nor(nor, "Image", F101_NOR_KERNEL_OFFSET,
@@ -237,9 +237,9 @@ int cmd_boot(int argc, const char **argv)
 	if (f101_validate_dtb())
 		return -1;
 
-	pr_info("Booting memory images: Linux=0x%08x DTB=0x%08x OpenSBI=0x%08x\n",
-		F101_LINUX_ADDR, F101_DTB_ADDR, F101_OPENSBI_ADDR);
-	f101_boot_opensbi();
+	pr_info("Booting memory images: Linux=0x%08x DTB=0x%08x SBI firmware=0x%08x\n",
+		F101_LINUX_ADDR, F101_DTB_ADDR, F101_SBI_ADDR);
+	f101_boot_sbi_firmware();
 }
 
 static const msh_command_entry commands[] = {

--- a/boards/yuzukineko/app_sram/spinor-boot/main.c
+++ b/boards/yuzukineko/app_sram/spinor-boot/main.c
@@ -5,13 +5,13 @@
  *
  * This SPL is loaded by the BROM (FEL, SD/eMMC or SPI NOR eGON image) into
  * SRAM. It brings up PSRAM, then copies the boot payloads stored at fixed
- * offsets in the on-board SPI NOR flash into PSRAM and hands off to OpenSBI
+ * offsets in the on-board SPI NOR flash into PSRAM and hands off to SBI firmware
  * (fw_jump), which in turn starts the Linux kernel.
  *
  * SPI NOR layout (all offsets are 2 KiB aligned):
  *	0x000000  bootloader   (this image, eGON BT0, up to 64 KiB)
  *	0x010000  device tree  (<= 256 KiB)
- *	0x050000  fw_jump.bin  (OpenSBI, 512 KiB)
+ *	0x050000  fw_jump.bin  (SBI firmware, 512 KiB)
  *	0x0d0000  Image        (Linux kernel, up to 6 MiB)
  *	0x6d0000  root filesystem
  */
@@ -42,18 +42,18 @@
 #define F101_RAM_SIZE		0x01000000U
 
 /*
- * PSRAM reservations, bottom up: Linux Image, then DTB, then OpenSBI pinned
+ * PSRAM reservations, bottom up: Linux Image, then DTB, then SBI firmware pinned
  * at the top of PSRAM. The heap for the SPIF sampling training lives in the
  * gap between the kernel region and the DTB reservation so a kernel load can
  * never overwrite live malloc state.
  */
 #define F101_KERNEL_SIZE	0x00600000U	/* Linux Image up to 6 MiB */
 #define F101_DTB_SIZE		0x00040000U	/* Device tree up to 256 KiB */
-#define F101_OPENSBI_SIZE	0x00080000U	/* OpenSBI fw_jump 512 KiB */
+#define F101_SBI_SIZE	0x00080000U	/* SBI firmware fw_jump 512 KiB */
 
 #define F101_LINUX_ADDR		(F101_RAM_BASE)
-#define F101_OPENSBI_ADDR	(F101_RAM_BASE + F101_RAM_SIZE - F101_OPENSBI_SIZE)
-#define F101_DTB_ADDR		(F101_OPENSBI_ADDR - F101_DTB_SIZE)
+#define F101_SBI_ADDR	(F101_RAM_BASE + F101_RAM_SIZE - F101_SBI_SIZE)
+#define F101_DTB_ADDR		(F101_SBI_ADDR - F101_DTB_SIZE)
 
 #define F101_HEAP_BASE		(F101_LINUX_ADDR + F101_KERNEL_SIZE)
 #define F101_HEAP_SIZE		(F101_DTB_ADDR - F101_HEAP_BASE)
@@ -64,17 +64,17 @@
  * maximum sizes (all offsets stay 2 KiB aligned).
  *	0x000000  bootloader  (this image, up to 64 KiB)
  *	0x010000  device tree (<= 256 KiB)
- *	0x050000  fw_jump.bin (OpenSBI, 512 KiB)
+ *	0x050000  fw_jump.bin (SBI firmware, 512 KiB)
  *	0x0d0000  Image       (Linux kernel, up to 6 MiB)
  *	0x6d0000  root filesystem
  */
 #define F101_BOOT_SIZE		0x00010000U
 
 #define F101_NOR_DTB_OFFSET		F101_BOOT_SIZE
-#define F101_NOR_OPENSBI_OFFSET		(F101_NOR_DTB_OFFSET + F101_DTB_SIZE)
-#define F101_NOR_KERNEL_OFFSET		(F101_NOR_OPENSBI_OFFSET + F101_OPENSBI_SIZE)
+#define F101_NOR_SBI_OFFSET		(F101_NOR_DTB_OFFSET + F101_DTB_SIZE)
+#define F101_NOR_KERNEL_OFFSET		(F101_NOR_SBI_OFFSET + F101_SBI_SIZE)
 
-typedef void (*opensbi_entry_t)(unsigned long hartid, uintptr_t fdt_addr);
+typedef void (*sbi_entry_t)(unsigned long hartid, uintptr_t fdt_addr);
 
 static int f101_psram_init(void)
 {
@@ -117,11 +117,11 @@ static int f101_validate_dtb(void)
 	return 0;
 }
 
-static __attribute__((noreturn)) void f101_boot_opensbi(void)
+static __attribute__((noreturn)) void f101_boot_sbi_firmware(void)
 {
-	opensbi_entry_t entry = (opensbi_entry_t)(uintptr_t)F101_OPENSBI_ADDR;
+	sbi_entry_t entry = (sbi_entry_t)(uintptr_t)F101_SBI_ADDR;
 
-	/* Make images loaded from the SPI NOR visible to OpenSBI and Linux. */
+	/* Make images loaded from the SPI NOR visible to SBI firmware and Linux. */
 	flush_dcache_all();
 	asm volatile("fence rw, rw\n\tfence.i" ::: "memory");
 
@@ -187,8 +187,8 @@ static int f101_load_images(spif_nor_t *nor)
 			       F101_DTB_ADDR, F101_DTB_SIZE) != 0)
 		return -1;
 
-	if (f101_read_from_nor(nor, "fw_jump", F101_NOR_OPENSBI_OFFSET,
-			       F101_OPENSBI_ADDR, F101_OPENSBI_SIZE) != 0)
+	if (f101_read_from_nor(nor, "fw_jump", F101_NOR_SBI_OFFSET,
+			       F101_SBI_ADDR, F101_SBI_SIZE) != 0)
 		return -1;
 
 	if (f101_read_from_nor(nor, "Image", F101_NOR_KERNEL_OFFSET,
@@ -209,9 +209,9 @@ int cmd_boot(int argc, const char **argv)
 	if (f101_validate_dtb())
 		return -1;
 
-	pr_info("Booting memory images: Linux=0x%08x DTB=0x%08x OpenSBI=0x%08x\n",
-		F101_LINUX_ADDR, F101_DTB_ADDR, F101_OPENSBI_ADDR);
-	f101_boot_opensbi();
+	pr_info("Booting memory images: Linux=0x%08x DTB=0x%08x SBI firmware=0x%08x\n",
+		F101_LINUX_ADDR, F101_DTB_ADDR, F101_SBI_ADDR);
+	f101_boot_sbi_firmware();
 }
 
 static const msh_command_entry commands[] = {

--- a/boards/yuzukineko/app_sram/spinor-boot/main.c
+++ b/boards/yuzukineko/app_sram/spinor-boot/main.c
@@ -123,7 +123,14 @@ static __attribute__((noreturn)) void f101_boot_sbi_firmware(void)
 
 	/* Make images loaded from the SPI NOR visible to SBI firmware and Linux. */
 	flush_dcache_all();
+	/* Keep D-cache off through PSRAM initialization and image loading. */
+	if (!(csr_read(mhcr) & MHCR_DE)) {
+		invalidate_dcache_all();
+		dcache_enable();
+		data_sync_barrier();
+	}
 	asm volatile("fence rw, rw\n\tfence.i" ::: "memory");
+	pr_info("SBI handoff: MHCR=0x%lx\n", csr_read(mhcr));
 
 	entry(0UL, F101_DTB_ADDR);
 	__builtin_unreachable();

--- a/boards/yuzukineko/app_sram/usb-boot-rv64i/main.c
+++ b/boards/yuzukineko/app_sram/usb-boot-rv64i/main.c
@@ -5,7 +5,7 @@
  *
  * This application is the in-memory sibling of spinor-boot: instead of
  * reading the boot payloads from SPI NOR, it expects the raw Linux Image,
- * DTB and OpenSBI fw_jump.bin to have already been staged in PSRAM by an
+ * DTB and SBI firwmare fw_jump.bin to have already been staged in PSRAM by an
  * external loader (for example over USB/FEL with xfel). It only validates
  * and boots what is already there.
  *
@@ -15,7 +15,7 @@
  * PSRAM layout (16 MiB PSRAM at SUNXI_PSRAM_BASE):
  *	0x40000000  Image        (Linux kernel, up to 6 MiB)
  *	0x40f40000  device tree  (<= 256 KiB)
- *	0x40f80000  fw_jump.bin  (OpenSBI, 512 KiB)
+ *	0x40f80000  fw_jump.bin  (SBI firwmare, 512 KiB)
  */
 
 #include <stdint.h>
@@ -37,21 +37,21 @@
 
 #define F101_KERNEL_SIZE	0x00600000U	/* Linux Image up to 6 MiB */
 #define F101_DTB_SIZE		0x00040000U	/* Device tree up to 256 KiB */
-#define F101_OPENSBI_SIZE	0x00080000U	/* OpenSBI fw_jump 512 KiB */
+#define F101_SBI_SIZE	0x00080000U	/* SBI firwmare fw_jump 512 KiB */
 
 #define F101_LINUX_ADDR		(F101_RAM_BASE)
-#define F101_OPENSBI_ADDR	(F101_RAM_BASE + F101_RAM_SIZE - F101_OPENSBI_SIZE)
-#define F101_DTB_ADDR		(F101_OPENSBI_ADDR - F101_DTB_SIZE)
+#define F101_SBI_ADDR	(F101_RAM_BASE + F101_RAM_SIZE - F101_SBI_SIZE)
+#define F101_DTB_ADDR		(F101_SBI_ADDR - F101_DTB_SIZE)
 
 /*
  * This entry is executed after the C907 has been reset into RV64 mode. It
  * must stay as raw instructions because this application itself is linked as
- * RV32. The reset vector points here, then the stub supplies the OpenSBI
+ * RV32. The reset vector points here, then the stub supplies the SBI firwmare
  * arguments before jumping to fw_jump in PSRAM.
  *
  *	0x00000513  addi a0, zero, 0
  *	0x40f405b7  lui  a1, 0x40f40       (F101_DTB_ADDR)
- *	0x40f802b7  lui  t0, 0x40f80       (F101_OPENSBI_ADDR)
+ *	0x40f802b7  lui  t0, 0x40f80       (F101_SBI_ADDR)
  *	0x0000100f  fence.i
  *	0x00028067  jr   t0
  */
@@ -86,7 +86,7 @@ static int f101_validate_dtb(void)
 	return 0;
 }
 
-static __attribute__((noreturn, noinline)) void f101_boot_opensbi(void)
+static __attribute__((noreturn, noinline)) void f101_boot_sbi_firmware(void)
 {
 	uintptr_t rv64_entry = (uintptr_t)f101_rv64_entry;
 
@@ -97,7 +97,7 @@ static __attribute__((noreturn, noinline)) void f101_boot_opensbi(void)
 	/*
 	 * C907 latches the ISA mode at reset. Program the reset vector and force
 	 * RV64, then use the RISC-V watchdog to restart the core. The reset lands
-	 * in f101_rv64_entry, which sets a0/a1 and jumps to OpenSBI.
+	 * in f101_rv64_entry, which sets a0/a1 and jumps to SBI firwmare.
 	 */
 	asm volatile(
 		"li t0, 0x02001d0c\n\t"
@@ -136,9 +136,9 @@ int cmd_boot(int argc, const char **argv)
 	if (f101_validate_dtb())
 		return -1;
 
-	pr_info("Booting memory images: Linux=0x%08x DTB=0x%08x OpenSBI=0x%08x\n",
-		F101_LINUX_ADDR, F101_DTB_ADDR, F101_OPENSBI_ADDR);
-	f101_boot_opensbi();
+	pr_info("Booting memory images: Linux=0x%08x DTB=0x%08x SBI firwmare=0x%08x\n",
+		F101_LINUX_ADDR, F101_DTB_ADDR, F101_SBI_ADDR);
+	f101_boot_sbi_firmware();
 }
 
 static const msh_command_entry commands[] = {

--- a/boards/yuzukineko/app_sram/usb-boot/main.c
+++ b/boards/yuzukineko/app_sram/usb-boot/main.c
@@ -5,7 +5,7 @@
  *
  * This application is the in-memory sibling of spinor-boot: instead of
  * reading the boot payloads from SPI NOR, it expects the raw Linux Image,
- * DTB and OpenSBI fw_jump.bin to have already been staged in PSRAM by an
+ * DTB and SBI firwmare fw_jump.bin to have already been staged in PSRAM by an
  * external loader (for example over USB/FEL with xfel). It only validates
  * and boots what is already there.
  *
@@ -15,7 +15,7 @@
  * PSRAM layout (16 MiB PSRAM at SUNXI_PSRAM_BASE):
  *	0x40000000  Image        (Linux kernel, up to 6 MiB)
  *	0x40f40000  device tree  (<= 256 KiB)
- *	0x40f80000  fw_jump.bin  (OpenSBI, 512 KiB)
+ *	0x40f80000  fw_jump.bin  (SBI firwmare, 512 KiB)
  */
 
 #include <stdint.h>
@@ -37,13 +37,13 @@
 
 #define F101_KERNEL_SIZE	0x00600000U	/* Linux Image up to 6 MiB */
 #define F101_DTB_SIZE		0x00040000U	/* Device tree up to 256 KiB */
-#define F101_OPENSBI_SIZE	0x00080000U	/* OpenSBI fw_jump 512 KiB */
+#define F101_SBI_SIZE	0x00080000U	/* SBI firwmare fw_jump 512 KiB */
 
 #define F101_LINUX_ADDR		(F101_RAM_BASE)
-#define F101_OPENSBI_ADDR	(F101_RAM_BASE + F101_RAM_SIZE - F101_OPENSBI_SIZE)
-#define F101_DTB_ADDR		(F101_OPENSBI_ADDR - F101_DTB_SIZE)
+#define F101_SBI_ADDR	(F101_RAM_BASE + F101_RAM_SIZE - F101_SBI_SIZE)
+#define F101_DTB_ADDR		(F101_SBI_ADDR - F101_DTB_SIZE)
 
-typedef void (*opensbi_entry_t)(unsigned long hartid, uintptr_t fdt_addr);
+typedef void (*sbi_entry_t)(unsigned long hartid, uintptr_t fdt_addr);
 
 static int f101_validate_dtb(void)
 {
@@ -68,11 +68,11 @@ static int f101_validate_dtb(void)
 	return 0;
 }
 
-static __attribute__((noreturn)) void f101_boot_opensbi(void)
+static __attribute__((noreturn)) void f101_boot_sbi_firmware(void)
 {
-	opensbi_entry_t entry = (opensbi_entry_t)(uintptr_t)F101_OPENSBI_ADDR;
+	sbi_entry_t entry = (sbi_entry_t)(uintptr_t)F101_SBI_ADDR;
 
-	/* Make the staged images visible to OpenSBI and Linux. */
+	/* Make the staged images visible to SBI firwmare and Linux. */
 	flush_dcache_all();
 	asm volatile("fence rw, rw\n\tfence.i" ::: "memory");
 
@@ -91,9 +91,9 @@ int cmd_boot(int argc, const char **argv)
 	if (f101_validate_dtb())
 		return -1;
 
-	pr_info("Booting memory images: Linux=0x%08x DTB=0x%08x OpenSBI=0x%08x\n",
-		F101_LINUX_ADDR, F101_DTB_ADDR, F101_OPENSBI_ADDR);
-	f101_boot_opensbi();
+	pr_info("Booting memory images: Linux=0x%08x DTB=0x%08x SBI firwmare=0x%08x\n",
+		F101_LINUX_ADDR, F101_DTB_ADDR, F101_SBI_ADDR);
+	f101_boot_sbi_firmware();
 }
 
 static const msh_command_entry commands[] = {


### PR DESCRIPTION
Rename OpenSBI variables to SBI firmware variables.

Performance comparison:

| Test case | Before (RustSBI) | After (RustSBI) | Speedup | OpenSBI |
|---|---:|---:|---:|---:|
| `base_spec` | 9885.38 | 322.06 | 30.69× | 444.01 |
| `base_probe` | 10272.35 | 344.02 | 29.86× | 483.01 |
| `base_mvendorid` | 9890.93 | 329.01 | 30.06× | 444.35 |
| `unsupported` | 9700.03 | 308.01 | 31.49× | 451.01 |
| `hsm_status` | 11540.03 | 365.18 | 31.60× | 610.01 |
| `time_set` | 10680.03 | 398.09 | 26.83× | 513.56 |
| `ipi_empty` | 13233.38 | 410.08 | 32.27× | 487.35 |
| `rfence_empty` | 17919.69 | 578.81 | 30.96× | 624.03 |
| `rfence_self` | 19540.03 | 940.51 | 20.78× | 2075.52 |
| `dbcn_empty` | 11640.03 | 350.01 | 33.26× | 655.51 |

Linux benchmark:

Linux 与 SPI

| 验证点 | Before | After |
|---|---:|---:|
| SPI NOR 分区发现，内核时间戳 | 2.842192 s | 0.575410 s |
| rootfs 挂载，内核时间戳 | 3.271247 s | 0.682474 s |
| 开始执行 init，内核时间戳 | 3.317457 s | 0.712475 s |
| 完整 Image 读取加 FNV 校验 | 21,564 ms | 2,763 ms |
| 校验 5,178,200 字节，FNV-1a=19769050 | PASS | PASS |
| Linux 用户空间与串口交互 | PASS | PASS |