### PR TITLE
fix(usb): restore SRAM ownership around FEL execution

### DIFF
--- a/drivers/usb/function/usb_fel.c
+++ b/drivers/usb/function/usb_fel.c
@@ -15,6 +15,11 @@
 #include <drivers/usb/function/usb_function.h>
 #include <drivers/usb/usb_manager.h>
 #include <drivers/soc/soc.h>
+#include <drivers/intc/intc.h>
+#include <drivers/usb/platform/usb_platform.h>
+#include <drivers/usb/usb_lowlevel.h>
+#include <drivers/usb/usb_regs.h>
+#include <dt-compatible/usb-dt.h>
 
 #define SUNXI_USB_FEL_MAX_TRANSFER	(64U * 1024U)
 #define SUNXI_USB_FEL_PIO_TRANSFER_MAX	512U
@@ -341,6 +346,61 @@ static void sunxi_usb_fel_finish_dma_write(void)
 }
 
 /**
+ * @brief Execute a FEL payload with USB platform resources released.
+ *
+ * The final response must be sent before calling this function. A returning
+ * payload must preserve the FEL image and restore its execution/clock context.
+ *
+ * @param entry Payload entry point.
+ * @return Zero on success, or a negative error code on failure.
+ */
+static int sunxi_usb_fel_run_payload(void (*entry)(void))
+{
+	sunxi_usb_t usb;
+	uint32_t gate_mask;
+	uint32_t dma_channels;
+	int ret;
+
+	if (entry == NULL || sunxi_usb_dt_read_alias(&usb, "usb0") != DRIVER_OK || usb.irq == 0U)
+		return -1;
+	gate_mask = BIT(usb.clock_gate_offset);
+	if (irq_disable((int)usb.irq) != DRIVER_OK)
+		return -1;
+
+	/* EXEC is handled after the previous transfer and its response finish.
+	 * Stop channels with DMA interrupts enabled without exposing manager state. */
+	dma_channels = readl(usb.base + USBC_REG_o_DMA_ENABLE);
+	while (dma_channels != 0U) {
+		unsigned channel = __builtin_ctz(dma_channels);
+
+		if (usb_dma_stop(channel) != 0) {
+			irq_enable((int)usb.irq);
+			return -1;
+		}
+		dma_channels &= dma_channels - 1U;
+	}
+
+	/* Freeze the controller without resetting endpoint addresses or toggles.
+	 * Interrupt masking alone does not stop hardware from using FIFO SRAM. */
+	clrbits_le32(usb.clock_gate_reg_base, gate_mask);
+	if (readl(usb.clock_gate_reg_base) & gate_mask) {
+		irq_enable((int)usb.irq);
+		return -1;
+	}
+	sunxi_usb_platform_deinit(&usb);
+	entry();
+
+	/* Reacquire SRAM before allowing the controller to access it again. */
+	ret = sunxi_usb_platform_init(&usb);
+	if (ret != DRIVER_OK)
+		return ret;
+	setbits_le32(usb.clock_gate_reg_base, gate_mask);
+	if (!(readl(usb.clock_gate_reg_base) & gate_mask))
+		return -1;
+	return irq_enable((int)usb.irq);
+}
+
+/**
  * @brief Implement the `sunxi_usb_fel_handle_header` USB operation.
  *
  * @param sunxi_ubuf The USB transfer buffer state.
@@ -436,7 +496,8 @@ static void sunxi_usb_fel_handle_header(sunxi_ubuf_t *sunxi_ubuf)
 	response_status = sunxi_usb_fel_send_transport_response(sunxi_usb_fel_transport_request.tab, 0U, status);
 	if (response_status == 0 && status == 0U && execute) {
 		sunxi_usb_fel_exec_pending = 0U;
-		entry();
+		if (sunxi_usb_fel_run_payload(entry) != 0)
+			printk_error("FEL: payload handoff failed\n");
 	}
 }
 

--- a/drivers/usb/platform/usb_sun252iw2.c
+++ b/drivers/usb/platform/usb_sun252iw2.c
@@ -11,6 +11,9 @@
 #define SUN252IW2_SYSCTRL_SRAM_REMAP 0x004U
 #define SUN252IW2_USB_SRAM_MASK	     (BIT(25) | BIT(27))
 
+static uint32_t saved_sram_mapping;
+static int sram_acquired;
+
 /**
  * @brief Reserve the sun252iw2 SRAM regions used by the USB FIFO.
  *
@@ -22,6 +25,11 @@ int sunxi_usb_platform_init(const sunxi_usb_t *usb)
 	if (usb == NULL)
 		return DRIVER_ERROR_INVALID;
 
+	if (!sram_acquired) {
+		saved_sram_mapping = readl(SUNXI_SYSCTRL_BASE + SUN252IW2_SYSCTRL_SRAM_REMAP) &
+			SUN252IW2_USB_SRAM_MASK;
+		sram_acquired = 1;
+	}
 	clrbits_le32(SUNXI_SYSCTRL_BASE + SUN252IW2_SYSCTRL_SRAM_REMAP, SUN252IW2_USB_SRAM_MASK);
 	return DRIVER_OK;
 }
@@ -33,5 +41,12 @@ int sunxi_usb_platform_init(const sunxi_usb_t *usb)
  */
 void sunxi_usb_platform_deinit(const sunxi_usb_t *usb)
 {
-	(void)usb;
+	if (usb == NULL || !sram_acquired)
+		return;
+
+	/* Restore only the banks acquired here, after the controller is stopped.
+	 * This restores the caller's mapping, not an assumed CPU mapping. */
+	clrsetbits_le32(SUNXI_SYSCTRL_BASE + SUN252IW2_SYSCTRL_SRAM_REMAP,
+		SUN252IW2_USB_SRAM_MASK, saved_sram_mapping);
+	sram_acquired = 0;
 }

--- a/drivers/usb/usb_lowlevel.c
+++ b/drivers/usb/usb_lowlevel.c
@@ -262,6 +262,9 @@ int usb_dma_release(uint32_t dma_index)
 		return ret;
 	}
 
+	ret = usb_dma_stop(dma_index);
+	if (ret != 0)
+		return ret;
 	usb_dma_used[dma_index] = 0; /**< Mark the DMA channel as unused */
 
 	return 0;
@@ -299,11 +302,15 @@ int usb_dma_start(uint32_t dma_index, uint32_t addr, uint32_t bytes)
 
 int usb_dma_stop(uint32_t dma_index)
 {
+	usb_controller_otg_t *otg = (usb_controller_otg_t *)usb_hd;
 	int ret = usb_index_check(dma_index);
 	if (ret) {
 		return ret;
 	}
 
+	clrbits_le32(otg->base_addr + USBC_REG_o_DMA_CONFIG + 0x10 * dma_index, BIT(31));
+	if (readl(otg->base_addr + USBC_REG_o_DMA_CONFIG + 0x10 * dma_index) & BIT(31))
+		return -1;
 	return lowlevel_usb_dma_int_stop(usb_hd, dma_index);
 }
 


### PR DESCRIPTION
Allow FEL payloads to reuse SRAM reserved by USB and resume communication after returning.

Fix USB FEL SRAM sync issue.